### PR TITLE
🎨 Palette: Add loading spinners to auth submit buttons

### DIFF
--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -6,7 +6,8 @@ import {
   Alert,
   AlertTitle,
   Typography,
-  useTheme
+  useTheme,
+  CircularProgress
 } from '@mui/material';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 
@@ -177,7 +178,7 @@ export default function CodeStep({
           fullWidth
           disabled={isLoading}
         >
-          Verificar
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Verificar'}
         </Button>
         <Button
           variant="outlined"

--- a/src/components/auth/steps/EmailStep.tsx
+++ b/src/components/auth/steps/EmailStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 
@@ -70,7 +71,7 @@ export default function EmailStep({
         fullWidth
         disabled={isLoading}
       >
-        {isLoading ? 'Enviando…' : 'Continuar'}
+        {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Continuar'}
       </Button>
     </Box>
   );

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -7,7 +7,8 @@ import {
   AlertTitle,
   InputAdornment,
   IconButton,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -118,7 +119,7 @@ export default function ExistingUserStep({
           fullWidth
           disabled={isLoading}
         >
-          Iniciar sesión
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Iniciar sesión'}
         </Button>
         <Button
           variant="outlined"

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -8,7 +8,8 @@ import {
   InputAdornment,
   IconButton,
   LinearProgress,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -157,7 +158,7 @@ export default function PasswordStep({
           fullWidth
           disabled={isLoading}
         >
-          {submitLabel}
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : submitLabel}
         </Button>
       </Box>
     </Box>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
@@ -180,7 +181,7 @@ export default function ProfileStep({
           fullWidth
           disabled={!first || !last || !birthDate || !gender || !!birthDateError || isLoading}
         >
-          Continuar
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Continuar'}
         </Button>
       </Box>
     </Box>


### PR DESCRIPTION
🎨 Palette: Add loading spinners to auth submit buttons

💡 What: Replaced static text with `CircularProgress` on submit buttons when `isLoading` is true.
🎯 Why: Provides immediate visual feedback to the user that their request is being processed.
📸 Before/After: Added loading indicator to EmailStep, PasswordStep, CodeStep, ExistingUserStep, and ProfileStep buttons.
♿ Accessibility: Indicates processing state visually rather than just disabling the button.

---
*PR created automatically by Jules for task [7438353445946600722](https://jules.google.com/task/7438353445946600722) started by @matiasrozenblum*