### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons for accessibility

### DIFF
--- a/src/components/IOSPushGuide.tsx
+++ b/src/components/IOSPushGuide.tsx
@@ -79,6 +79,7 @@ export default function IOSPushGuide() {
         <IconButton
           color="inherit"
           size="small"
+          aria-label={expanded ? "Contraer guía de notificaciones" : "Expandir guía de notificaciones"}
           onClick={() => setExpanded(!expanded)}
         >
           {expanded ? <ExpandLess /> : <ExpandMore />}

--- a/src/components/backoffice/ProgramSchedulesSection.tsx
+++ b/src/components/backoffice/ProgramSchedulesSection.tsx
@@ -452,10 +452,10 @@ export function ProgramSchedulesSection({
                               />
                             </TableCell>
                             <TableCell>
-                              <IconButton onClick={handleUpdateSchedule} size="small">
+                              <IconButton aria-label="Actualizar horario" onClick={handleUpdateSchedule} size="small">
                                 <Check />
                               </IconButton>
-                              <IconButton onClick={handleCloseEditDialog} size="small">
+                              <IconButton aria-label="Cancelar edición" onClick={handleCloseEditDialog} size="small">
                                 <Close />
                               </IconButton>
                             </TableCell>
@@ -468,10 +468,10 @@ export function ProgramSchedulesSection({
                             <TableCell>{formatTime(schedule.start_time)}</TableCell>
                             <TableCell>{formatTime(schedule.end_time)}</TableCell>
                             <TableCell>
-                              <IconButton onClick={() => handleOpenEditDialog(schedule)} size="small">
+                              <IconButton aria-label="Editar horario" onClick={() => handleOpenEditDialog(schedule)} size="small">
                                 <Edit />
                               </IconButton>
-                              <IconButton onClick={() => handleDeleteSchedule(schedule.id)} size="small">
+                              <IconButton aria-label="Eliminar horario" onClick={() => handleDeleteSchedule(schedule.id)} size="small">
                                 <Delete />
                               </IconButton>
                             </TableCell>
@@ -508,10 +508,10 @@ export function ProgramSchedulesSection({
                         <TableCell>{formatTime(schedule.startTime)}</TableCell>
                         <TableCell>{formatTime(schedule.endTime)}</TableCell>
                         <TableCell>
-                          <IconButton onClick={() => handleEditPendingSchedule(schedule.id)} size="small">
+                          <IconButton aria-label="Editar horario pendiente" onClick={() => handleEditPendingSchedule(schedule.id)} size="small">
                             <Edit />
                           </IconButton>
-                          <IconButton onClick={() => handleDeletePendingSchedule(schedule.id)} size="small">
+                          <IconButton aria-label="Eliminar horario pendiente" onClick={() => handleDeletePendingSchedule(schedule.id)} size="small">
                             <Delete />
                           </IconButton>
                         </TableCell>
@@ -650,6 +650,7 @@ export function ProgramSchedulesSection({
                         <ListItemSecondaryAction>
                           <IconButton
                             edge="end"
+                            aria-label="Eliminar horario de creación masiva"
                             onClick={() => handleRemoveBulkSchedule(index)}
                             size="small"
                           >


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to multiple icon-only `<IconButton>` components across `IOSPushGuide.tsx` and `ProgramSchedulesSection.tsx`.

🎯 **Why**: To improve accessibility for screen readers. Icon-only buttons lack descriptive text, making their function ambiguous to visually impaired users relying on screen reading technology.

♿ **Accessibility**: Enhanced screen reader support by providing explicit, translated (Spanish) labels for actions like "Expandir guía", "Editar horario", "Eliminar horario", etc., ensuring parity in context for all users.

✅ Verified with Playwright UI testing and ran successful `pnpm lint`/`build`.

---
*PR created automatically by Jules for task [10158819251365680674](https://jules.google.com/task/10158819251365680674) started by @matiasrozenblum*