### PR TITLE
🎨 Palette: Add ARIA labels to IconButtons in ProgramSchedulesSection

### DIFF
--- a/src/components/backoffice/ProgramSchedulesSection.tsx
+++ b/src/components/backoffice/ProgramSchedulesSection.tsx
@@ -452,10 +452,10 @@ export function ProgramSchedulesSection({
                               />
                             </TableCell>
                             <TableCell>
-                              <IconButton onClick={handleUpdateSchedule} size="small">
+                              <IconButton aria-label="Aceptar" onClick={handleUpdateSchedule} size="small">
                                 <Check />
                               </IconButton>
-                              <IconButton onClick={handleCloseEditDialog} size="small">
+                              <IconButton aria-label="Cancelar" onClick={handleCloseEditDialog} size="small">
                                 <Close />
                               </IconButton>
                             </TableCell>
@@ -468,10 +468,10 @@ export function ProgramSchedulesSection({
                             <TableCell>{formatTime(schedule.start_time)}</TableCell>
                             <TableCell>{formatTime(schedule.end_time)}</TableCell>
                             <TableCell>
-                              <IconButton onClick={() => handleOpenEditDialog(schedule)} size="small">
+                              <IconButton aria-label="Editar horario" onClick={() => handleOpenEditDialog(schedule)} size="small">
                                 <Edit />
                               </IconButton>
-                              <IconButton onClick={() => handleDeleteSchedule(schedule.id)} size="small">
+                              <IconButton aria-label="Eliminar horario" onClick={() => handleDeleteSchedule(schedule.id)} size="small">
                                 <Delete />
                               </IconButton>
                             </TableCell>
@@ -508,10 +508,10 @@ export function ProgramSchedulesSection({
                         <TableCell>{formatTime(schedule.startTime)}</TableCell>
                         <TableCell>{formatTime(schedule.endTime)}</TableCell>
                         <TableCell>
-                          <IconButton onClick={() => handleEditPendingSchedule(schedule.id)} size="small">
+                          <IconButton aria-label="Editar horario pendiente" onClick={() => handleEditPendingSchedule(schedule.id)} size="small">
                             <Edit />
                           </IconButton>
-                          <IconButton onClick={() => handleDeletePendingSchedule(schedule.id)} size="small">
+                          <IconButton aria-label="Eliminar horario pendiente" onClick={() => handleDeletePendingSchedule(schedule.id)} size="small">
                             <Delete />
                           </IconButton>
                         </TableCell>
@@ -649,6 +649,7 @@ export function ProgramSchedulesSection({
                         />
                         <ListItemSecondaryAction>
                           <IconButton
+                            aria-label="Eliminar horario en lote"
                             edge="end"
                             onClick={() => handleRemoveBulkSchedule(index)}
                             size="small"


### PR DESCRIPTION
🎨 Palette: Added missing aria-labels to IconButtons in ProgramSchedulesSection

💡 What: Added appropriate `aria-label`s to all icon-only `<IconButton>`s in `src/components/backoffice/ProgramSchedulesSection.tsx`.
🎯 Why: Without these labels, screen reader users wouldn't know what actions the buttons perform (Accept, Cancel, Edit, Delete), breaking the accessibility.
📸 Before/After: Visuals are unchanged. The HTML source now includes proper ARIA tags.
♿ Accessibility: Improved screen reader announcements for the schedule management section of the backoffice interface.

---
*PR created automatically by Jules for task [12915500807121063712](https://jules.google.com/task/12915500807121063712) started by @matiasrozenblum*