### PR TITLE
🎨 Palette: Add ARIA labels to backoffice categories icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2025-04-04 - Adding ARIA labels to MUI IconButton components
+**Learning:** Found several Material UI `<IconButton>` components in the backoffice tables (e.g., categories page) missing `aria-label`s. This is an accessibility issue pattern across administrative interfaces where icon-only buttons like edit, delete, and reorder arrows are heavily used.
+**Action:** When adding or modifying `<IconButton>` elements for common actions (edit, delete, move), always ensure an explicit `aria-label` in Spanish is provided so screen readers can interpret the action correctly.

--- a/src/app/backoffice/categories/page.tsx
+++ b/src/app/backoffice/categories/page.tsx
@@ -255,6 +255,7 @@ export default function CategoriesPage() {
                       size="small" 
                       onClick={() => handleMoveLeft(index)}
                       disabled={index === 0}
+                      aria-label="Mover a la izquierda"
                     >
                       <ArrowBack />
                     </IconButton>
@@ -265,6 +266,7 @@ export default function CategoriesPage() {
                       size="small" 
                       onClick={() => handleMoveRight(index)}
                       disabled={index === categories.length - 1}
+                      aria-label="Mover a la derecha"
                     >
                       <ArrowForward />
                     </IconButton>
@@ -324,10 +326,10 @@ export default function CategoriesPage() {
                   />
                 </TableCell>
                 <TableCell>
-                  <IconButton onClick={() => handleOpenDialog(category)}>
+                  <IconButton aria-label="Editar categoría" onClick={() => handleOpenDialog(category)}>
                     <EditIcon />
                   </IconButton>
-                  <IconButton onClick={() => handleDelete(category.id)}>
+                  <IconButton aria-label="Eliminar categoría" onClick={() => handleDelete(category.id)}>
                     <DeleteIcon />
                   </IconButton>
                 </TableCell>


### PR DESCRIPTION
💡 **What**: Added descriptive `aria-label`s to the icon-only buttons (Move left, Move right, Edit, Delete) in the categories table.
🎯 **Why**: Icon-only buttons without accessible names cannot be understood by screen reader users. Adding explicit labels in Spanish ensures equal access to functionality.
♿ **Accessibility**: Provides correct semantic context for assistive technologies interacting with the data table row actions.

---
*PR created automatically by Jules for task [13336782676446919713](https://jules.google.com/task/13336782676446919713) started by @matiasrozenblum*