### PR TITLE
🎨 Palette: Add loading spinners to auth submit buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2026-04-06 - Adding loading spinner to async submit button
+**Learning:** Implementing visual feedback for asynchronous operations improves UX. In MUI forms, adding an inline `<CircularProgress size={24} color="inherit" />` within `<Button>` components accurately communicates `isLoading` states without removing the layout structure.
+**Action:** Always include a visual loading indicator (like `CircularProgress`) for submit buttons associated with async operations (e.g., login, registration) to inform the user that their request is being processed.

--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -6,7 +6,8 @@ import {
   Alert,
   AlertTitle,
   Typography,
-  useTheme
+  useTheme,
+  CircularProgress
 } from '@mui/material';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 
@@ -177,7 +178,7 @@ export default function CodeStep({
           fullWidth
           disabled={isLoading}
         >
-          Verificar
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Verificar'}
         </Button>
         <Button
           variant="outlined"

--- a/src/components/auth/steps/EmailStep.tsx
+++ b/src/components/auth/steps/EmailStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 
@@ -70,7 +71,7 @@ export default function EmailStep({
         fullWidth
         disabled={isLoading}
       >
-        {isLoading ? 'Enviando…' : 'Continuar'}
+        {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Continuar'}
       </Button>
     </Box>
   );

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -7,7 +7,8 @@ import {
   AlertTitle,
   InputAdornment,
   IconButton,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -118,7 +119,7 @@ export default function ExistingUserStep({
           fullWidth
           disabled={isLoading}
         >
-          Iniciar sesión
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Iniciar sesión'}
         </Button>
         <Button
           variant="outlined"

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -8,7 +8,8 @@ import {
   InputAdornment,
   IconButton,
   LinearProgress,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -157,7 +158,7 @@ export default function PasswordStep({
           fullWidth
           disabled={isLoading}
         >
-          {submitLabel}
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : submitLabel}
         </Button>
       </Box>
     </Box>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
@@ -180,7 +181,7 @@ export default function ProfileStep({
           fullWidth
           disabled={!first || !last || !birthDate || !gender || !!birthDateError || isLoading}
         >
-          Continuar
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Continuar'}
         </Button>
       </Box>
     </Box>


### PR DESCRIPTION
💡 What: Added visual `CircularProgress` loading indicators to the main submit buttons across the auth steps (`EmailStep`, `ExistingUserStep`, `PasswordStep`, `CodeStep`, `ProfileStep`).
🎯 Why: Provides clear visual feedback during asynchronous operations, making the interface feel more responsive and keeping users informed that their request is being processed.
📸 Before/After: Button text was replaced with an inline spinner while `isLoading` is true.
♿ Accessibility: Ensures the disabled state during loading is accompanied by a visual cue.

---
*PR created automatically by Jules for task [9081280032849085671](https://jules.google.com/task/9081280032849085671) started by @matiasrozenblum*