### PR TITLE
🎨 Palette: Add loading spinners to auth submit buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-03-24 - Loading states for Material UI Buttons
+**Learning:** Found an interaction pattern where async operations lacked clear loading states in forms (e.g. auth steps). Simply changing button text to "Enviando..." doesn't offer as strong of a visual cue to users as a spinner.
+**Action:** When working with `<Button>` components in this project that have an `isLoading` prop, always consistently use `<CircularProgress size={24} color="inherit" />` inline as the `startIcon` to visually indicate loading states for a better UX experience.

--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -6,7 +6,8 @@ import {
   Alert,
   AlertTitle,
   Typography,
-  useTheme
+  useTheme,
+  CircularProgress
 } from '@mui/material';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 
@@ -176,6 +177,7 @@ export default function CodeStep({
           variant="contained"
           fullWidth
           disabled={isLoading}
+          startIcon={isLoading ? <CircularProgress size={24} color="inherit" /> : undefined}
         >
           Verificar
         </Button>

--- a/src/components/auth/steps/EmailStep.tsx
+++ b/src/components/auth/steps/EmailStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 
@@ -69,6 +70,7 @@ export default function EmailStep({
         variant="contained"
         fullWidth
         disabled={isLoading}
+        startIcon={isLoading ? <CircularProgress size={24} color="inherit" /> : undefined}
       >
         {isLoading ? 'Enviando…' : 'Continuar'}
       </Button>

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -7,7 +7,8 @@ import {
   AlertTitle,
   InputAdornment,
   IconButton,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -117,6 +118,7 @@ export default function ExistingUserStep({
           variant="contained"
           fullWidth
           disabled={isLoading}
+          startIcon={isLoading ? <CircularProgress size={24} color="inherit" /> : undefined}
         >
           Iniciar sesión
         </Button>

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -8,7 +8,8 @@ import {
   InputAdornment,
   IconButton,
   LinearProgress,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -156,6 +157,7 @@ export default function PasswordStep({
           variant="contained"
           fullWidth
           disabled={isLoading}
+          startIcon={isLoading ? <CircularProgress size={24} color="inherit" /> : undefined}
         >
           {submitLabel}
         </Button>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
@@ -179,6 +180,7 @@ export default function ProfileStep({
           variant="contained"
           fullWidth
           disabled={!first || !last || !birthDate || !gender || !!birthDateError || isLoading}
+          startIcon={isLoading ? <CircularProgress size={24} color="inherit" /> : undefined}
         >
           Continuar
         </Button>


### PR DESCRIPTION
🎨 **Palette: Added loading spinners to auth submit buttons**

💡 **What:** Added `<CircularProgress>` to the primary submit buttons across all authentication steps (`CodeStep`, `EmailStep`, `ExistingUserStep`, `PasswordStep`, `ProfileStep`) when `isLoading` is true.

🎯 **Why:** Previously, submitting a form would just disable the button or change the text slightly (e.g., to "Enviando..."). Adding a standard Material UI spinner provides a much stronger, universally recognized visual cue that a background operation is occurring, reducing user confusion and repeated clicks during slow network requests.

♿ **Accessibility / UX:** Provides clearer visual feedback of system status (Nielsen Heuristic #1), helping users understand that the app is working and their input was received.

📸 **Before/After:** (N/A visual change is a standard MUI circular progress icon inside the button).

---
*PR created automatically by Jules for task [10344586760576619503](https://jules.google.com/task/10344586760576619503) started by @matiasrozenblum*