### PR TITLE
🎨 Palette: Add missing aria-label to config delete button

### DIFF
--- a/src/app/backoffice/configs/page.tsx
+++ b/src/app/backoffice/configs/page.tsx
@@ -96,7 +96,7 @@ const ConfigPage = () => {
                   />
                 </TableCell>
                 <TableCell>
-                  <IconButton onClick={() => handleDeleteConfig(config.key)}>
+                  <IconButton aria-label="Eliminar configuración" onClick={() => handleDeleteConfig(config.key)}>
                     <Delete />
                   </IconButton>
                   {editConfig?.key === config.key && editConfig.value !== config.value && (


### PR DESCRIPTION
💡 What: Added `aria-label="Eliminar configuración"` to the Delete `IconButton` in `src/app/backoffice/configs/page.tsx`.
🎯 Why: It's an accessibility issue. Icon-only buttons need an `aria-label` for screen reader compatibility. This is consistent with other Spanish translations in the codebase.
♿ Accessibility: The button is now clearly identifiable by screen readers instead of being read as an unlabeled element.

---
*PR created automatically by Jules for task [13293602958808623189](https://jules.google.com/task/13293602958808623189) started by @matiasrozenblum*