### PR TITLE
🎨 Palette: Add loading spinners to auth submit buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-05-18 - Visual Loading Indicators in Form Submissions
+**Learning:** Adding explicit visual feedback (like a loading spinner inline within the primary button) during async operations like form submissions significantly improves user experience. It provides immediate acknowledgement of the user's action and sets expectations while reducing perceived wait time.
+**Action:** When building forms in this project, consistently use `<CircularProgress size={24} color="inherit" />` inline within `<Button>` components to visually indicate `isLoading` states for a better UX experience.

--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -6,7 +6,8 @@ import {
   Alert,
   AlertTitle,
   Typography,
-  useTheme
+  useTheme,
+  CircularProgress
 } from '@mui/material';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 
@@ -176,8 +177,9 @@ export default function CodeStep({
           variant="contained"
           fullWidth
           disabled={isLoading}
+          aria-label={isLoading ? 'Verificando' : undefined}
         >
-          Verificar
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Verificar'}
         </Button>
         <Button
           variant="outlined"

--- a/src/components/auth/steps/EmailStep.tsx
+++ b/src/components/auth/steps/EmailStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 
@@ -69,8 +70,9 @@ export default function EmailStep({
         variant="contained"
         fullWidth
         disabled={isLoading}
+        aria-label={isLoading ? 'Cargando' : undefined}
       >
-        {isLoading ? 'Enviando…' : 'Continuar'}
+        {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Continuar'}
       </Button>
     </Box>
   );

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -7,7 +7,8 @@ import {
   AlertTitle,
   InputAdornment,
   IconButton,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -117,8 +118,9 @@ export default function ExistingUserStep({
           variant="contained"
           fullWidth
           disabled={isLoading}
+          aria-label={isLoading ? 'Iniciando sesión' : undefined}
         >
-          Iniciar sesión
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Iniciar sesión'}
         </Button>
         <Button
           variant="outlined"

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -8,7 +8,8 @@ import {
   InputAdornment,
   IconButton,
   LinearProgress,
-  Typography
+  Typography,
+  CircularProgress
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -156,8 +157,9 @@ export default function PasswordStep({
           variant="contained"
           fullWidth
           disabled={isLoading}
+          aria-label={isLoading ? 'Procesando' : undefined}
         >
-          {submitLabel}
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : submitLabel}
         </Button>
       </Box>
     </Box>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -5,7 +5,8 @@ import {
   Button,
   Alert,
   AlertTitle,
-  InputAdornment
+  InputAdornment,
+  CircularProgress
 } from '@mui/material';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
@@ -179,8 +180,9 @@ export default function ProfileStep({
           variant="contained"
           fullWidth
           disabled={!first || !last || !birthDate || !gender || !!birthDateError || isLoading}
+          aria-label={isLoading ? 'Guardando perfil' : undefined}
         >
-          Continuar
+          {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Continuar'}
         </Button>
       </Box>
     </Box>


### PR DESCRIPTION
💡 What: Added inline `CircularProgress` spinners to the submit buttons across all authentication steps (`EmailStep`, `CodeStep`, `ExistingUserStep`, `PasswordStep`, `ProfileStep`) during their `isLoading` states, and ensured they maintain an accessible name via `aria-label`.
🎯 Why: To provide immediate visual feedback during async operations (like network requests), improving the perceived performance and preventing users from clicking multiple times. Adding `aria-label` ensures screen readers are aware of the processing state.
📸 Before/After: Visual changes demonstrated via playwright screenshot.
♿ Accessibility: Added Spanish `aria-label` strings when loading so screen readers announce "Cargando", "Verificando", "Iniciando sesión", etc. instead of a blank string when the text is replaced by the `<CircularProgress>` component.

---
*PR created automatically by Jules for task [8480962241746724326](https://jules.google.com/task/8480962241746724326) started by @matiasrozenblum*