### PR TITLE
🎨 Palette: [Accessibility] Add `aria-label` to backoffice table icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2025-04-13 - Backoffice Accessibility Label Language Inconsistency
+**Learning:** Some components inside `src/components/backoffice/` contain `aria-label` elements in English (e.g. "delete" in `ManageDevicesDialog.tsx`) instead of Spanish, causing inconsistencies.
+**Action:** When updating or reviewing backoffice elements, prioritize translating English ARIA labels to Spanish to keep the interface consistent for screen readers.

--- a/src/components/backoffice/ManageDevicesDialog.tsx
+++ b/src/components/backoffice/ManageDevicesDialog.tsx
@@ -88,7 +88,7 @@ export function ManageDevicesDialog({ open, onClose, user, session, onDeviceDele
                 <ListItem
                   key={device.id}
                   secondaryAction={
-                    <IconButton edge="end" aria-label="delete" onClick={() => handleDeleteDevice(device.id)}>
+                    <IconButton edge="end" aria-label="Eliminar dispositivo" onClick={() => handleDeleteDevice(device.id)}>
                       <Delete />
                     </IconButton>
                   }

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1165,10 +1165,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <IconButton onClick={() => handleEdit(override)} color="primary">
+                            <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
                               <Edit />
                             </IconButton>
-                            <IconButton onClick={() => handleDelete(override.id)} color="error">
+                            <IconButton aria-label="Eliminar" onClick={() => handleDelete(override.id)} color="error">
                               <Delete />
                             </IconButton>
                           </Box>


### PR DESCRIPTION
🎨 Palette: [Accessibility] Add `aria-label` to backoffice table icon buttons

💡 **What:** Added missing `aria-label` properties ("Editar", "Eliminar") to the edit/delete `IconButton` actions in the WeeklyOverridesTable fallback UI. Additionally, translated an existing English `aria-label` ("delete") to Spanish ("Eliminar dispositivo") in ManageDevicesDialog.

🎯 **Why:** To ensure screen readers have clear context for what actions icon-only buttons perform, fixing a recurring accessibility gap.

♿ **Accessibility:**
- Added missing context for "edit" and "delete" operations in tables.
- Standardized language to Spanish to match the rest of the application context.

---
*PR created automatically by Jules for task [1298040785902674673](https://jules.google.com/task/1298040785902674673) started by @matiasrozenblum*