### PR TITLE
Release 1.16.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,21 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ## [Unreleased]
 
 ### Added
-- Add loading spinners (CircularProgress) to auth submit buttons with accessible aria-labels during loading state (enhancement/jules-prs-consolidation)
-- Add aria-labels to icon-only buttons across backoffice: configs delete, categories move/edit/delete, ProgramSchedulesSection accept/cancel/edit/delete/bulk-delete, IOSPushGuide expand/collapse, and mobile live schedule FAB (enhancement/jules-prs-consolidation)
 
 ### Changed
+- Switch Datadog RUM to opt-out model: initialize for all non-admin users and only skip events on explicit analytics rejection, matching PostHog coverage (enhancement/datadog-opt-out-model)
 
 ### Removed
 
 ### Fixed
+
+---
+
+## [1.16.12] - 2026-04-12
+
+### Added
+- Add loading spinners (CircularProgress) to auth submit buttons with accessible aria-labels during loading state (enhancement/jules-prs-consolidation)
+- Add aria-labels to icon-only buttons across backoffice: configs delete, categories move/edit/delete, ProgramSchedulesSection accept/cancel/edit/delete/bulk-delete, IOSPushGuide expand/collapse, and mobile live schedule FAB (enhancement/jules-prs-consolidation)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Added
 
 ### Changed
-- Switch Datadog RUM to opt-out model: initialize for all non-admin users and only skip events on explicit analytics rejection, matching PostHog coverage (enhancement/datadog-opt-out-model)
 
 ### Removed
 
 ### Fixed
+
+---
+
+## [1.16.13] - 2026-04-13
+
+### Changed
+- Switch Datadog RUM to opt-out model: initialize for all non-admin users and only skip events on explicit analytics rejection, matching PostHog coverage (enhancement/datadog-opt-out-model)
 
 ---
 

--- a/src/components/ConditionalTrackingLoader.tsx
+++ b/src/components/ConditionalTrackingLoader.tsx
@@ -49,29 +49,13 @@ export function ConditionalTrackingLoader() {
     }
   }, [hasConsent, consent, isAdmin]);
 
-  // Initialize Datadog RUM when analytics consent is given (skip for admin users).
-  // We read consent directly from localStorage instead of relying on the context
-  // state because CookieConsentProvider loads it asynchronously in a useEffect,
-  // and children effects run before parent effects in React — so the context
-  // would still be null on first run.
+  // Initialize Datadog RUM for all non-admin users (opt-out model, same as PostHog).
+  // Events are only sent if the user hasn't explicitly rejected analytics —
+  // that check lives in gaEvent(), not here.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     if (isAdmin) return;
-
-    let hasAnalyticsConsent = false;
-    try {
-      const stored = localStorage.getItem('cookie-consent');
-      if (stored) {
-        const consentData = JSON.parse(stored);
-        hasAnalyticsConsent = consentData.preferences?.analytics || false;
-      }
-    } catch {
-      return;
-    }
-
-    if (hasAnalyticsConsent) {
-      initDatadogRum();
-    }
+    initDatadogRum();
   }, [isAdmin]);
 
   // Initialize Google Analytics when analytics consent is given (skip for admin users)

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -162,21 +162,25 @@ type NextData = {
  * Si hay una sesión activa, incluye datos del usuario como gender and age
  */
 export const event = ({ action, params, userData }: { action: string; params?: GtagEventParams; userData?: { id?: string; gender?: string; birthDate?: string; role?: string } }) => {
-  // Check if analytics consent is given
+  // Resolve consent state:
+  //   hasAnalyticsConsent — user explicitly accepted analytics
+  //   analyticsExplicitlyRejected — user explicitly rejected analytics
+  //   Neither flag set — user hasn't responded yet (opt-out model applies)
   const consent = localStorage.getItem('cookie-consent');
   let hasAnalyticsConsent = false;
+  let analyticsExplicitlyRejected = false;
   if (consent) {
     try {
       const consentData = JSON.parse(consent);
-      hasAnalyticsConsent = consentData.preferences?.analytics || false;
+      hasAnalyticsConsent = consentData.preferences?.analytics === true;
+      analyticsExplicitlyRejected = consentData.preferences?.analytics === false;
     } catch {
       // Don't track if consent data is invalid
       return;
     }
-  } else {
-    // Don't track if no consent data
-    return;
   }
+  // If user hasn't responded yet, GA4 and PostHog still require explicit consent,
+  // but Datadog uses opt-out model (tracks unless explicitly rejected).
 
   // Use userData if provided, otherwise try to get from window.__NEXT_DATA__
   let user = userData;
@@ -225,8 +229,9 @@ export const event = ({ action, params, userData }: { action: string; params?: G
     } catch { /* non-fatal */ }
   }
 
-  // Only send to Datadog RUM if analytics consent is given and SDK is initialized
-  if (hasAnalyticsConsent && datadogInited) {
+  // Send to Datadog RUM using opt-out model: track unless user explicitly rejected.
+  // Mirrors PostHog's behavior so both tools have comparable coverage.
+  if (!analyticsExplicitlyRejected && datadogInited) {
     try {
       datadogRum.addAction(action, eventData);
     } catch (e) {


### PR DESCRIPTION
## [1.16.13] - 2026-04-13

### Changed
- Switch Datadog RUM to opt-out model: initialize for all non-admin users and only skip events on explicit analytics rejection, matching PostHog coverage (enhancement/datadog-opt-out-model)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)