### PR TITLE
fix: analytics channel_name, Datadog Session Replay, and simultaneous programs panelists

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -59,6 +59,11 @@ Create a release for production deployment.
 ### 8. Report
 - Show the PR URL.
 - Remind: "Merging this PR to main will trigger the production deploy on Vercel."
+- **IMPORTANT — back-merge reminder**: After you manually merge the PR to `main`, run the following commands to sync `develop` and avoid CHANGELOG conflicts on the next release:
+  ```bash
+  git checkout develop && git pull origin main && git push origin develop
+  ```
+  This must be done after every release merge to main.
 
 ## Important
 - Always show the CHANGELOG entry and get user confirmation before committing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ### Fixed
 - Fix click_youtube_live analytics events sending undefined channel_name (shown as "unknown" in PostHog breakdowns); make channelName required in ProgramBlock and add explicit fallback (fix/analytics-channel-name-and-datadog-replay)
+- Hide panelists in ProgramBlock when multiple programs run simultaneously to prioritize title space in reduced-height blocks (fix/hide-panelists-on-simultaneous-programs)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Added
 
 ### Changed
+- Enable Datadog Session Replay at 20% sample rate (fix/analytics-channel-name-and-datadog-replay)
 
 ### Removed
 
 ### Fixed
+- Fix click_youtube_live analytics events sending undefined channel_name (shown as "unknown" in PostHog breakdowns); make channelName required in ProgramBlock and add explicit fallback (fix/analytics-channel-name-and-datadog-replay)
 
 ---
 

--- a/src/components/ProgramBlock.tsx
+++ b/src/components/ProgramBlock.tsx
@@ -37,7 +37,7 @@ interface Props {
   panelists?: { id: string; name: string }[];
   logo_url?: string;
   color?: string;
-  channelName?: string;
+  channelName: string;
   isToday?: boolean;
   is_live?: boolean;
   stream_url?: string | null;
@@ -170,7 +170,7 @@ export const ProgramBlock: React.FC<Props> = ({
       params: {
         category: 'program',
         program_name: name,
-        channel_name: channelName,
+        channel_name: channelName || 'unknown',
       },
       userData: typedSession?.user
     });

--- a/src/components/ProgramBlock.tsx
+++ b/src/components/ProgramBlock.tsx
@@ -773,7 +773,7 @@ export const ProgramBlock: React.FC<Props> = ({
                     >
                       {name.toUpperCase()}
                     </Typography>
-                    {panelists && panelists.length > 0 && (!isMobile || (isMobile && widthPx > 120)) && (
+                    {panelists && panelists.length > 0 && !totalMultipleStreams && (!isMobile || (isMobile && widthPx > 120)) && (
                       <Typography
                         variant="caption"
                         sx={{

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -24,12 +24,13 @@ export function initDatadogRum(): void {
       env: process.env.NODE_ENV === 'production' ? 'production' : 'staging',
       version: process.env.NEXT_PUBLIC_APP_VERSION,
       sessionSampleRate: 100,
-      sessionReplaySampleRate: 0,
+      sessionReplaySampleRate: 20,
       trackUserInteractions: true,
       trackResources: true,
       trackLongTasks: true,
       defaultPrivacyLevel: 'mask-user-input',
     });
+    datadogRum.startSessionReplayRecording();
     datadogInited = true;
   } catch (e) {
     console.warn('[Datadog] init FAILED:', e);


### PR DESCRIPTION
## Summary
- Fix `click_youtube_live` analytics events arriving with `channel_name: "unknown"` in PostHog breakdowns — `channelName` was optional in `ProgramBlock` Props; now required with explicit `|| 'unknown'` fallback so the property is always a string in the payload
- Enable Datadog Session Replay at 20% sample rate (`sessionReplaySampleRate: 20` + `startSessionReplayRecording()`)
- Hide panelists in `ProgramBlock` when multiple programs run simultaneously — prioritizes title space in reduced-height blocks

## Test plan
- [ ] Click a live YouTube program → verify `click_youtube_live` event in PostHog has correct `channel_name` (not "unknown")
- [ ] Click a deferred YouTube program → verify `click_youtube_deferred` still shows correct channel name
- [ ] Open Datadog RUM → confirm session replays are being recorded (~20% of sessions)
- [ ] Trigger a simultaneous-programs scenario → verify panelists are hidden on overlapping blocks while title remains visible
- [ ] Verify non-overlapping programs still show panelists normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)