### PR TITLE
feat: channel logo image upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ## [Unreleased]
 
 ### Added
+- Add channel logo image upload via Supabase in admin panel, with preview and manual URL fallback (feature/channel-logo-upload)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ## [Unreleased]
 
 ### Added
-- Add channel logo image upload via Supabase in admin panel, with preview and manual URL fallback (feature/channel-logo-upload)
 
 ### Changed
 
 ### Removed
 
 ### Fixed
+
+---
+
+## [1.17.0] - 2026-04-16
+
+### Added
+- Add channel logo image upload via Supabase in admin panel, with preview and manual URL fallback (feature/channel-logo-upload)
 
 ---
 

--- a/src/app/api/channels/upload/route.ts
+++ b/src/app/api/channels/upload/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAccessToken } from '@/utils/auth-server';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = await requireAccessToken(request);
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const formData = await request.formData();
+    const file = formData.get('file') as File;
+
+    if (!file) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    const backendFormData = new FormData();
+    backendFormData.append('file', file);
+
+    const response = await fetch(`${API_BASE_URL}/channels/upload`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: backendFormData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('Backend API error:', response.status, errorText);
+      return NextResponse.json({ error: 'Failed to upload image' }, { status: response.status });
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    // requireAccessToken throws a NextResponse on 401; treat that as a normal response
+    if (error instanceof Response) {
+      return error;
+    }
+    console.error('Error uploading channel logo:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/backoffice/channels/page.tsx
+++ b/src/app/backoffice/channels/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useSessionContext } from '@/contexts/SessionContext';
 import {
+  Avatar,
   Box,
   Button,
   Paper,
@@ -478,27 +479,25 @@ export default function ChannelsPage() {
               </label>
               {logoPreview && (
                 <Box sx={{ mb: 2 }}>
-                  <Typography variant="body2" sx={{ mb: 1 }}>Vista previa:</Typography>
-                  <Box
+                  <Typography variant="body2" sx={{ mb: 1 }}>
+                    Vista previa (tal como aparece en la grilla):
+                  </Typography>
+                  <Avatar
+                    src={logoPreview}
+                    alt="Logo preview"
+                    variant="rounded"
                     sx={{
-                      position: 'relative',
-                      width: 140,
-                      height: 140,
-                      borderRadius: 2,
-                      overflow: 'hidden',
-                      border: '1px solid',
-                      borderColor: 'divider',
-                      backgroundColor: 'background.paper',
+                      width: 130,
+                      height: 68,
+                      background: formData.background_color || '#ffffff',
+                      boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                      '& img': {
+                        objectFit: 'contain',
+                        width: '100%',
+                        height: '100%',
+                      },
                     }}
-                  >
-                    <Image
-                      unoptimized
-                      src={logoPreview}
-                      alt="Logo preview"
-                      fill
-                      style={{ objectFit: 'contain' }}
-                    />
-                  </Box>
+                  />
                 </Box>
               )}
               <TextField

--- a/src/app/backoffice/channels/page.tsx
+++ b/src/app/backoffice/channels/page.tsx
@@ -55,6 +55,8 @@ export default function ChannelsPage() {
   const [savingOrder, setSavingOrder] = useState(false);
   const [loadingConfigs, setLoadingConfigs] = useState(false);
   const [clearingCache, setClearingCache] = useState<number | null>(null);
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [logoPreview, setLogoPreview] = useState<string | null>(null);
 
   useEffect(() => {
     if (status === 'authenticated') fetchChannels();
@@ -151,6 +153,7 @@ export default function ChannelsPage() {
       setEditingChannel(channel);
       setFormData({ name: channel.name, logo_url: channel.logo_url || '', handle: channel.handle || '', is_visible: channel.is_visible ?? true, background_color: channel.background_color || '', show_only_when_scheduled: channel.show_only_when_scheduled ?? false, youtube_fetch_enabled: true, youtube_fetch_override_holiday: true });
       setSelectedCategories(channel.categories || []);
+      setLogoPreview(channel.logo_url || null);
       
       // Fetch current config values for this channel before opening dialog
       if (channel.handle) {
@@ -178,6 +181,7 @@ export default function ChannelsPage() {
       setEditingChannel(null);
       setFormData({ name: '', logo_url: '', handle: '', is_visible: false, background_color: '', show_only_when_scheduled: false, youtube_fetch_enabled: true, youtube_fetch_override_holiday: true });
       setSelectedCategories([]);
+      setLogoPreview(null);
       // For new channels, open immediately (no config fetch needed)
       setOpenDialog(true);
     }
@@ -189,6 +193,7 @@ export default function ChannelsPage() {
     setFormData({ name: '', logo_url: '', handle: '', is_visible: false, background_color: '', show_only_when_scheduled: false, youtube_fetch_enabled: true, youtube_fetch_override_holiday: true });
     setSelectedCategories([]);
     setLoadingConfigs(false);
+    setLogoPreview(null);
   };
 
   const handleSubmit = async () => {
@@ -273,6 +278,48 @@ export default function ChannelsPage() {
       setError(err instanceof Error ? err.message : 'Error al limpiar la caché');
     } finally {
       setClearingCache(null);
+    }
+  };
+
+  const handleLogoFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      setError('Por favor selecciona un archivo de imagen');
+      return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      setError('El archivo es demasiado grande. Máximo 5MB');
+      return;
+    }
+
+    setUploadingLogo(true);
+
+    try {
+      const uploadFormData = new FormData();
+      uploadFormData.append('file', file);
+
+      const response = await fetch('/api/channels/upload', {
+        method: 'POST',
+        body: uploadFormData,
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        throw new Error(body?.error || 'Error al subir el logo');
+      }
+
+      const data = await response.json();
+      setFormData(prev => ({ ...prev, logo_url: data.url }));
+      setLogoPreview(data.url);
+      setSuccess('Logo subido correctamente');
+    } catch (err: unknown) {
+      console.error('Error uploading logo:', err);
+      setError(err instanceof Error ? err.message : 'Error al subir el logo');
+    } finally {
+      setUploadingLogo(false);
     }
   };
 
@@ -406,12 +453,65 @@ export default function ChannelsPage() {
               onChange={e => setFormData({ ...formData, name: e.target.value })}
               fullWidth required
             />
-            <TextField
-              label="URL del Logo"
-              value={formData.logo_url}
-              onChange={e => setFormData({ ...formData, logo_url: e.target.value })}
-              fullWidth
-            />
+            <Box>
+              <Typography variant="body2" sx={{ mb: 1, fontWeight: 500 }}>
+                Logo del Canal (recomendado 200×200px, PNG con fondo transparente)
+              </Typography>
+              <input
+                accept="image/*"
+                style={{ display: 'none' }}
+                id="channel-logo-upload"
+                type="file"
+                onChange={handleLogoFileSelect}
+                disabled={uploadingLogo}
+              />
+              <label htmlFor="channel-logo-upload">
+                <Button
+                  variant="outlined"
+                  component="span"
+                  fullWidth
+                  disabled={uploadingLogo}
+                  sx={{ mb: 2 }}
+                >
+                  {uploadingLogo ? 'Subiendo...' : 'Subir Logo'}
+                </Button>
+              </label>
+              {logoPreview && (
+                <Box sx={{ mb: 2 }}>
+                  <Typography variant="body2" sx={{ mb: 1 }}>Vista previa:</Typography>
+                  <Box
+                    sx={{
+                      position: 'relative',
+                      width: 140,
+                      height: 140,
+                      borderRadius: 2,
+                      overflow: 'hidden',
+                      border: '1px solid',
+                      borderColor: 'divider',
+                      backgroundColor: 'background.paper',
+                    }}
+                  >
+                    <Image
+                      unoptimized
+                      src={logoPreview}
+                      alt="Logo preview"
+                      fill
+                      style={{ objectFit: 'contain' }}
+                    />
+                  </Box>
+                </Box>
+              )}
+              <TextField
+                label="URL del Logo"
+                value={formData.logo_url}
+                onChange={e => {
+                  setFormData({ ...formData, logo_url: e.target.value });
+                  setLogoPreview(e.target.value || null);
+                }}
+                fullWidth
+                helperText="Se completa automáticamente al subir. También podés ingresar una URL manualmente."
+              />
+            </Box>
             <TextField
               label="Handle de YouTube"
               value={formData.handle}


### PR DESCRIPTION
## Summary
- Add image upload for channel logos in the admin panel (backoffice), replacing manual URL entry with a file upload + Supabase storage flow
- Preview replicates the exact schedule grid dimensions (130×68px, rounded Avatar, objectFit: contain) with the channel's background color applied in real time
- Manual URL field kept as editable fallback (same pattern as streamers)

## New files
- `src/app/api/channels/upload/route.ts` — NextAuth-protected proxy to `POST /channels/upload` on the backend

## Backend dependency
Requires a new `POST /channels/upload` endpoint on the backend (same logic as `POST /streamers/upload`, bucket: `channel-logos`). No DB migration needed — `logo_url` column already exists.

## Test plan
- [ ] Open a channel in backoffice → upload a logo image → verify preview shows correct dimensions and background color
- [ ] Change background color field → verify preview updates in real time
- [ ] Manually enter a logo URL → verify preview appears
- [ ] Save channel → verify logo appears correctly in the schedule grid
- [ ] Test with PNG (transparent background) and JPG

🤖 Generated with [Claude Code](https://claude.com/claude-code)