### PR TITLE
🎨 Palette: Add Tooltips and ARIA labels to Program Actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2026-04-20 - Improve Icon-only Buttons UX
+**Learning:** Sighted users also benefit from clear descriptions of icon-only action buttons. Wrapping `IconButton` with `Tooltip` provides a hover label, complementing the screen-reader-focused `aria-label`.
+**Action:** Always wrap `IconButton` in a `<Tooltip title="...">` element to provide a hover description, in addition to assigning the `aria-label` attribute.

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   FormControlLabel,
   Checkbox,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -343,11 +344,21 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa" arrow>
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa" arrow>
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas" arrow>
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 What: Wrapped the icon-only action buttons (Edit, Delete, Manage Panelists) in `src/app/backoffice/programs/page.tsx` with Material-UI `Tooltip` components and added descriptive `aria-label`s.
🎯 Why: To improve the user experience for both sighted users (via hover tooltips) and users relying on assistive technology (via aria-labels), making the interface more accessible and intuitive.
♿ Accessibility: Added `aria-label` attributes to ensure screen readers provide context for the icon buttons.

---
*PR created automatically by Jules for task [1236064497693013446](https://jules.google.com/task/1236064497693013446) started by @matiasrozenblum*