### PR TITLE
🎨 Palette: Add Tooltips and aria-labels to backoffice icon buttons

### DIFF
--- a/src/app/backoffice/banners/page.tsx
+++ b/src/app/backoffice/banners/page.tsx
@@ -25,6 +25,7 @@ import {
   Card,
   CardMedia,
   CardContent,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -448,20 +449,26 @@ export default function BannersPage() {
                         size="small"
                       />
                       <Box>
-                        <IconButton
-                          size="small"
-                          onClick={() => handleOpenDialog(banner)}
-                          color="primary"
-                        >
-                          <EditIcon />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          onClick={() => setDeleteConfirm({ open: true, banner })}
-                          color="error"
-                        >
-                          <DeleteIcon />
-                        </IconButton>
+                        <Tooltip title="Editar banner">
+                          <IconButton
+                            aria-label="Editar banner"
+                            size="small"
+                            onClick={() => handleOpenDialog(banner)}
+                            color="primary"
+                          >
+                            <EditIcon />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Eliminar banner">
+                          <IconButton
+                            aria-label="Eliminar banner"
+                            size="small"
+                            onClick={() => setDeleteConfirm({ open: true, banner })}
+                            color="error"
+                          >
+                            <DeleteIcon />
+                          </IconButton>
+                        </Tooltip>
                       </Box>
                     </Box>
                   </CardContent>

--- a/src/app/backoffice/channels/page.tsx
+++ b/src/app/backoffice/channels/page.tsx
@@ -24,6 +24,7 @@ import {
   Alert,
   Snackbar,
   Switch,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -382,12 +383,20 @@ export default function ChannelsPage() {
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
                     #{idx + 1}
-                    <IconButton size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
-                      <ArrowUpward fontSize="small" />
-                    </IconButton>
-                    <IconButton size="small" onClick={() => handleMoveDown(idx)} disabled={idx === channels.length - 1}>
-                      <ArrowDownward fontSize="small" />
-                    </IconButton>
+                    <Tooltip title="Subir canal">
+                      <span>
+                        <IconButton aria-label="Subir canal" size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
+                          <ArrowUpward fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title="Bajar canal">
+                      <span>
+                        <IconButton aria-label="Bajar canal" size="small" onClick={() => handleMoveDown(idx)} disabled={idx === channels.length - 1}>
+                          <ArrowDownward fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                   </Box>
                 </TableCell>
                 <TableCell>
@@ -416,7 +425,11 @@ export default function ChannelsPage() {
                 </TableCell>
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
-                    <IconButton onClick={() => handleOpenDialog(channel)}><EditIcon /></IconButton>
+                    <Tooltip title="Editar canal">
+                      <IconButton aria-label="Editar canal" onClick={() => handleOpenDialog(channel)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
                     <Switch
                       checked={channel.is_visible}
                       onChange={() => handleToggleVisibility(channel)}
@@ -424,16 +437,24 @@ export default function ChannelsPage() {
                       size="small"
                     />
                     {channel.handle && (
-                      <IconButton
-                        onClick={() => handleClearCache(channel)}
-                        disabled={clearingCache === channel.id}
-                        title="Limpiar caché de estado en vivo"
-                        color="secondary"
-                      >
-                        <RefreshIcon />
-                      </IconButton>
+                      <Tooltip title="Limpiar caché de estado en vivo">
+                        <span>
+                          <IconButton
+                            aria-label="Limpiar caché de estado en vivo"
+                            onClick={() => handleClearCache(channel)}
+                            disabled={clearingCache === channel.id}
+                            color="secondary"
+                          >
+                            <RefreshIcon />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
                     )}
-                    <IconButton onClick={() => handleDelete(channel.id)}><DeleteIcon /></IconButton>
+                    <Tooltip title="Eliminar canal">
+                      <IconButton aria-label="Eliminar canal" onClick={() => handleDelete(channel.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 </TableCell>
               </TableRow>

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   FormControlLabel,
   Checkbox,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -343,11 +344,21 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa">
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa">
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas">
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );

--- a/src/app/backoffice/streamers/page.tsx
+++ b/src/app/backoffice/streamers/page.tsx
@@ -28,6 +28,7 @@ import {
   FormControl,
   InputLabel,
   Chip,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -514,13 +515,21 @@ export default function StreamersPage() {
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
                     #{idx + 1}
-                    <IconButton size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
-                      {/* using a simple caret by unicode to avoid extra imports */}
-                      <span style={{ fontSize: 14 }}>▲</span>
-                    </IconButton>
-                    <IconButton size="small" onClick={() => handleMoveDown(idx)} disabled={idx === streamers.length - 1}>
-                      <span style={{ fontSize: 14 }}>▼</span>
-                    </IconButton>
+                    <Tooltip title="Subir streamer">
+                      <span>
+                        <IconButton aria-label="Subir streamer" size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
+                          {/* using a simple caret by unicode to avoid extra imports */}
+                          <span style={{ fontSize: 14 }}>▲</span>
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title="Bajar streamer">
+                      <span>
+                        <IconButton aria-label="Bajar streamer" size="small" onClick={() => handleMoveDown(idx)} disabled={idx === streamers.length - 1}>
+                          <span style={{ fontSize: 14 }}>▼</span>
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                   </Box>
                 </TableCell>
                 <TableCell>
@@ -570,63 +579,79 @@ export default function StreamersPage() {
                 </TableCell>
                 <TableCell>
                   <Box display="flex" gap={0.5}>
-                    <IconButton
-                      size="small"
-                      onClick={() => handleSyncLiveStatus(streamer.id, 'kick')}
-                      disabled={!hasService(streamer, StreamingService.KICK) || syncingService?.streamerId === streamer.id}
-                      title={hasService(streamer, StreamingService.KICK) ? 'Sync Kick' : 'No tiene Kick'}
-                      sx={{
-                        backgroundColor: hasService(streamer, StreamingService.KICK) ? 'rgba(83, 252, 24, 0.1)' : undefined,
-                        '&:hover': {
-                          backgroundColor: hasService(streamer, StreamingService.KICK) ? 'rgba(83, 252, 24, 0.2)' : undefined,
-                        },
-                        opacity: hasService(streamer, StreamingService.KICK) ? 1 : 0.3,
-                      }}
-                    >
-                      {syncingService?.streamerId === streamer.id && syncingService?.service === 'kick' ? (
-                        <CircularProgress size={18} />
-                      ) : (
-                        <Image
-                          unoptimized
-                          src={SERVICE_ICONS.kick}
-                          alt="Kick"
-                          width={18}
-                          height={18}
-                          style={{ objectFit: 'contain' }}
-                        />
-                      )}
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      onClick={() => handleSyncLiveStatus(streamer.id, 'twitch')}
-                      disabled={!hasService(streamer, StreamingService.TWITCH) || syncingService?.streamerId === streamer.id}
-                      title={hasService(streamer, StreamingService.TWITCH) ? 'Sync Twitch' : 'No tiene Twitch'}
-                      sx={{
-                        backgroundColor: hasService(streamer, StreamingService.TWITCH) ? 'rgba(145, 70, 255, 0.1)' : undefined,
-                        '&:hover': {
-                          backgroundColor: hasService(streamer, StreamingService.TWITCH) ? 'rgba(145, 70, 255, 0.2)' : undefined,
-                        },
-                        opacity: hasService(streamer, StreamingService.TWITCH) ? 1 : 0.3,
-                      }}
-                    >
-                      {syncingService?.streamerId === streamer.id && syncingService?.service === 'twitch' ? (
-                        <CircularProgress size={18} />
-                      ) : (
-                        <Image
-                          unoptimized
-                          src={SERVICE_ICONS.twitch}
-                          alt="Twitch"
-                          width={18}
-                          height={18}
-                          style={{ objectFit: 'contain' }}
-                        />
-                      )}
-                    </IconButton>
+                    <Tooltip title={hasService(streamer, StreamingService.KICK) ? 'Sincronizar Kick' : 'No tiene Kick'}>
+                      <span>
+                        <IconButton
+                          aria-label={hasService(streamer, StreamingService.KICK) ? 'Sincronizar Kick' : 'No tiene Kick'}
+                          size="small"
+                          onClick={() => handleSyncLiveStatus(streamer.id, 'kick')}
+                          disabled={!hasService(streamer, StreamingService.KICK) || syncingService?.streamerId === streamer.id}
+                          sx={{
+                            backgroundColor: hasService(streamer, StreamingService.KICK) ? 'rgba(83, 252, 24, 0.1)' : undefined,
+                            '&:hover': {
+                              backgroundColor: hasService(streamer, StreamingService.KICK) ? 'rgba(83, 252, 24, 0.2)' : undefined,
+                            },
+                            opacity: hasService(streamer, StreamingService.KICK) ? 1 : 0.3,
+                          }}
+                        >
+                          {syncingService?.streamerId === streamer.id && syncingService?.service === 'kick' ? (
+                            <CircularProgress size={18} />
+                          ) : (
+                            <Image
+                              unoptimized
+                              src={SERVICE_ICONS.kick}
+                              alt="Kick"
+                              width={18}
+                              height={18}
+                              style={{ objectFit: 'contain' }}
+                            />
+                          )}
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title={hasService(streamer, StreamingService.TWITCH) ? 'Sincronizar Twitch' : 'No tiene Twitch'}>
+                      <span>
+                        <IconButton
+                          aria-label={hasService(streamer, StreamingService.TWITCH) ? 'Sincronizar Twitch' : 'No tiene Twitch'}
+                          size="small"
+                          onClick={() => handleSyncLiveStatus(streamer.id, 'twitch')}
+                          disabled={!hasService(streamer, StreamingService.TWITCH) || syncingService?.streamerId === streamer.id}
+                          sx={{
+                            backgroundColor: hasService(streamer, StreamingService.TWITCH) ? 'rgba(145, 70, 255, 0.1)' : undefined,
+                            '&:hover': {
+                              backgroundColor: hasService(streamer, StreamingService.TWITCH) ? 'rgba(145, 70, 255, 0.2)' : undefined,
+                            },
+                            opacity: hasService(streamer, StreamingService.TWITCH) ? 1 : 0.3,
+                          }}
+                        >
+                          {syncingService?.streamerId === streamer.id && syncingService?.service === 'twitch' ? (
+                            <CircularProgress size={18} />
+                          ) : (
+                            <Image
+                              unoptimized
+                              src={SERVICE_ICONS.twitch}
+                              alt="Twitch"
+                              width={18}
+                              height={18}
+                              style={{ objectFit: 'contain' }}
+                            />
+                          )}
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                   </Box>
                 </TableCell>
                 <TableCell>
-                  <IconButton onClick={() => handleOpenDialog(streamer)}><EditIcon /></IconButton>
-                  <IconButton onClick={() => handleDelete(streamer.id)}><DeleteIcon /></IconButton>
+                  <Tooltip title="Editar streamer">
+                    <IconButton aria-label="Editar streamer" onClick={() => handleOpenDialog(streamer)}>
+                      <EditIcon />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar streamer">
+                    <IconButton aria-label="Eliminar streamer" onClick={() => handleDelete(streamer.id)}>
+                      <DeleteIcon />
+                    </IconButton>
+                  </Tooltip>
                 </TableCell>
               </TableRow>
             ))}
@@ -760,13 +785,16 @@ export default function StreamersPage() {
                         placeholder="https://www.youtube.com/@channelname"
                       />
                     ) : null}
-                    <IconButton
-                      onClick={() => handleRemoveService(index)}
-                      color="error"
-                      sx={{ mt: 1 }}
-                    >
-                      <RemoveIcon />
-                    </IconButton>
+                    <Tooltip title="Eliminar servicio">
+                      <IconButton
+                        aria-label="Eliminar servicio"
+                        onClick={() => handleRemoveService(index)}
+                        color="error"
+                        sx={{ mt: 1 }}
+                      >
+                        <RemoveIcon />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 )
               })}


### PR DESCRIPTION
🎨 Palette: Added Tooltips and ARIA labels to icon-only buttons in backoffice.

💡 **What:** Added `<Tooltip>` wrappers and `aria-label` attributes to multiple icon-only `IconButton` elements across the backoffice pages (`programs`, `channels`, `streamers`, `banners`). Conditionally disabled buttons were wrapped in `<span>` tags to ensure tooltips still fire properly in MUI.
🎯 **Why:** Icon-only buttons without accessible names cannot be interpreted by screen readers. Tooltips additionally assist all users in understanding the function of the button without needing text labels.
♿ **Accessibility:** Solves a major accessibility gap in the backoffice tables. Fully keyboard navigable and correctly read by screen readers.

---
*PR created automatically by Jules for task [11715313570425228954](https://jules.google.com/task/11715313570425228954) started by @matiasrozenblum*