### PR TITLE
🎨 Palette: Add aria-label to Streamer subscription button

### DIFF
--- a/src/components/StreamersClient.tsx
+++ b/src/components/StreamersClient.tsx
@@ -623,6 +623,7 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
                           {/* Subscription Button */}
                           <Tooltip title={streamer.is_subscribed ? "Desuscribirse" : "Suscribirse"}>
                             <IconButton
+                              aria-label={streamer.is_subscribed ? `Desuscribirse de ${streamer.name}` : `Suscribirse a ${streamer.name}`}
                               className="subscription-button"
                               onClick={(e) => handleToggleSubscription(e, streamer)}
                               disabled={subscriptionLoading[streamer.id]}


### PR DESCRIPTION
### 💡 What:
Added a dynamic `aria-label` attribute to the icon-only "Suscribirse" button in the `StreamersClient` component based on whether the user is already subscribed to the streamer or not.

### 🎯 Why:
The subscription button in the streamers view only contained a hover tooltip but lacked an accessible name for screen reader users. Adding a dynamic `aria-label` in Spanish ensures that non-sighted users can easily understand the action the button performs ("Suscribirse a [streamer]" vs "Desuscribirse de [streamer]") without needing to trigger a tooltip.

### 📸 Before/After:
No visual changes.

### ♿ Accessibility:
* Screen readers will now announce the exact action the user is taking when focusing on the subscription button for streamers.

---
*PR created automatically by Jules for task [1903758497599924914](https://jules.google.com/task/1903758497599924914) started by @matiasrozenblum*