### PR TITLE
🎨 Palette: Add missing ARIA labels to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2025-02-18 - Missing ARIA Labels on Icon Buttons
+**Learning:** Found a recurring accessibility pattern across standard table interactions (edit, delete) and subscription states where icon-only buttons lacked `aria-label` attributes, which prevents screen readers from understanding the button's purpose and state.
+**Action:** Always ensure that icon-only buttons, especially those performing standard actions (Editar, Eliminar, Suscribirse), have dynamic `aria-label` attributes that accurately reflect the action in Spanish.

--- a/src/components/StreamersClient.tsx
+++ b/src/components/StreamersClient.tsx
@@ -623,6 +623,7 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
                           {/* Subscription Button */}
                           <Tooltip title={streamer.is_subscribed ? "Desuscribirse" : "Suscribirse"}>
                             <IconButton
+                              aria-label={streamer.is_subscribed ? "Desuscribirse" : "Suscribirse"}
                               className="subscription-button"
                               onClick={(e) => handleToggleSubscription(e, streamer)}
                               disabled={subscriptionLoading[streamer.id]}

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1165,10 +1165,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <IconButton onClick={() => handleEdit(override)} color="primary">
+                            <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
                               <Edit />
                             </IconButton>
-                            <IconButton onClick={() => handleDelete(override.id)} color="error">
+                            <IconButton aria-label="Eliminar" onClick={() => handleDelete(override.id)} color="error">
                               <Delete />
                             </IconButton>
                           </Box>


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` attributes to multiple `IconButton` components across the project (specifically in `StreamersClient` and `WeeklyOverridesTable` mobile views). The labels are dynamic and correctly reflect the state of the component in Spanish (e.g., "Suscribirse" vs "Desuscribirse", "Editar", "Eliminar").

### 🎯 Why
Icon-only buttons rely entirely on their visual representation to communicate their purpose. Screen readers cannot interpret these icons without a proper textual alternative. By adding dynamic `aria-label`s, we ensure that visually impaired users or those relying on screen readers can understand the purpose of the buttons and successfully interact with them.

### 📸 Before/After
No visual changes were introduced, as `aria-label` is an invisible accessibility attribute.

### ♿ Accessibility
- Ensured screen readers will correctly announce the intention of the interactive button.
- Followed existing UX standard in `.Jules/palette.md` for proper UI labeling (Spanish).

---
*PR created automatically by Jules for task [8319467929190397337](https://jules.google.com/task/8319467929190397337) started by @matiasrozenblum*