### PR TITLE
🎨 Palette: Add Tooltips and aria-labels to Programs table actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-05-18 - Missing Tooltips and aria-labels on IconButton in Backoffice Tables
+**Learning:** Found a widespread a11y issue where icon-only components (`IconButton`) in Material UI backoffice tables (like the programs table) lack `aria-label`s and `Tooltip` components, preventing proper screen-reader announcements and sighted user context. This matches the rule that icon-only buttons must have an explicit `aria-label` attribute in Spanish and be wrapped in a `<Tooltip>`.
+**Action:** Always wrap `<IconButton>` in `<Tooltip title="...">` and provide an explicit `aria-label` in Spanish mirroring the tooltip text when building or modifying backoffice tables in this app.

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   FormControlLabel,
   Checkbox,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -343,11 +344,21 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa">
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa">
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas">
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 **What**: Added Material UI `Tooltip` wrappers and Spanish `aria-label` tags to the icon-only action buttons (Edit, Delete, Manage Panelists) in the Backoffice Programs Table.

🎯 **Why**: Previously, these buttons lacked explicit context for screen readers and sighted users who were unsure what the bare icons meant. This improves overall accessibility and creates a clearer user experience in the CMS.

♿ **Accessibility**: Replaces bare `<IconButton><EditIcon /></IconButton>` blocks with explicitly labeled `<Tooltip title="Editar programa"><IconButton aria-label="Editar programa"><EditIcon /></IconButton></Tooltip>` per Material UI accessibility best practices and internal standard rules.

---
*PR created automatically by Jules for task [3889556126141855913](https://jules.google.com/task/3889556126141855913) started by @matiasrozenblum*