### PR TITLE
🎨 Palette: Accessible Tooltips and ARIA Labels for Icon Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-05-03 - Accessible Tooltips for Disabled Buttons
+**Learning:** In Material UI, when `IconButton` components are disabled, standard tooltips (`<Tooltip>`) do not trigger because pointer events are disabled on the button itself. Screen readers and mouse users both miss out on contextual info (like why it's disabled or what the button does).
+**Action:** Wrap disabled `IconButton` components inside a `<span>` element within the `<Tooltip>` to restore the tooltip's hover and focus states, improving accessibility for all users. Also ensure `IconButton` elements have state-dependent `aria-label`s to dynamically communicate the action (e.g., "Suscribirse" vs "Desuscribirse").

--- a/src/components/StreamersClient.tsx
+++ b/src/components/StreamersClient.tsx
@@ -622,40 +622,43 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
 
                           {/* Subscription Button */}
                           <Tooltip title={streamer.is_subscribed ? "Desuscribirse" : "Suscribirse"}>
-                            <IconButton
-                              className="subscription-button"
-                              onClick={(e) => handleToggleSubscription(e, streamer)}
-                              disabled={subscriptionLoading[streamer.id]}
-                              sx={{
-                                position: 'absolute',
-                                top: 6,
-                                left: 6,
-                                zIndex: 10,
-                                backgroundColor: 'rgba(0,0,0,0.6)',
-                                color: 'white',
-                                padding: '4px',
-                                opacity: { xs: 1, md: streamer.is_subscribed ? 1 : 0 }, // Always visible on mobile, reveal on hover for desktop if not subscribed
-                                transform: { xs: 'scale(1)', md: streamer.is_subscribed ? 'scale(1)' : 'scale(0.8)' },
-                                transition: 'all 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
-                                '&:hover': {
-                                  backgroundColor: 'rgba(0,0,0,0.8)',
-                                  transform: 'scale(1.1)',
-                                },
-                                '&.Mui-disabled': {
-                                  backgroundColor: 'rgba(0,0,0,0.4)',
-                                  color: 'rgba(255,255,255,0.5)',
-                                }
-                              }}
-                              size="small"
-                            >
-                              {subscriptionLoading[streamer.id] ? (
-                                <CircularProgress size={16} color="inherit" />
-                              ) : streamer.is_subscribed ? (
-                                <Notifications fontSize="small" sx={{ color: '#FFD700' }} /> // Gold color for subscribed
-                              ) : (
-                                <NotificationsNone fontSize="small" />
-                              )}
-                            </IconButton>
+                            <span>
+                              <IconButton
+                                aria-label={streamer.is_subscribed ? "Desuscribirse" : "Suscribirse"}
+                                className="subscription-button"
+                                onClick={(e) => handleToggleSubscription(e, streamer)}
+                                disabled={subscriptionLoading[streamer.id]}
+                                sx={{
+                                  position: 'absolute',
+                                  top: 6,
+                                  left: 6,
+                                  zIndex: 10,
+                                  backgroundColor: 'rgba(0,0,0,0.6)',
+                                  color: 'white',
+                                  padding: '4px',
+                                  opacity: { xs: 1, md: streamer.is_subscribed ? 1 : 0 }, // Always visible on mobile, reveal on hover for desktop if not subscribed
+                                  transform: { xs: 'scale(1)', md: streamer.is_subscribed ? 'scale(1)' : 'scale(0.8)' },
+                                  transition: 'all 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275)',
+                                  '&:hover': {
+                                    backgroundColor: 'rgba(0,0,0,0.8)',
+                                    transform: 'scale(1.1)',
+                                  },
+                                  '&.Mui-disabled': {
+                                    backgroundColor: 'rgba(0,0,0,0.4)',
+                                    color: 'rgba(255,255,255,0.5)',
+                                  }
+                                }}
+                                size="small"
+                              >
+                                {subscriptionLoading[streamer.id] ? (
+                                  <CircularProgress size={16} color="inherit" />
+                                ) : streamer.is_subscribed ? (
+                                  <Notifications fontSize="small" sx={{ color: '#FFD700' }} /> // Gold color for subscribed
+                                ) : (
+                                  <NotificationsNone fontSize="small" />
+                                )}
+                              </IconButton>
+                            </span>
                           </Tooltip>
 
                           {streamer.logo_url ? (

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1165,10 +1165,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <IconButton onClick={() => handleEdit(override)} color="primary">
+                            <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
                               <Edit />
                             </IconButton>
-                            <IconButton onClick={() => handleDelete(override.id)} color="error">
+                            <IconButton aria-label="Eliminar" onClick={() => handleDelete(override.id)} color="error">
                               <Delete />
                             </IconButton>
                           </Box>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to icon-only buttons and wrapped disabled `IconButton`s in `span` elements so tooltips correctly display over them.
🎯 Why: Enhances accessibility for screen readers and improves the UX for all users by ensuring context tooltips appear correctly even when action buttons are disabled.
♿ Accessibility: Provides explicit ARIA labels in Spanish ('Suscribirse', 'Desuscribirse', 'Editar', 'Eliminar') for icon buttons and ensures disabled elements do not lose pointer events, restoring tooltip functionality.

---
*PR created automatically by Jules for task [12396473518049852034](https://jules.google.com/task/12396473518049852034) started by @matiasrozenblum*