### PR TITLE
🎨 Palette: Add tooltips and ARIA labels to Programs table IconButtons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-05-18 - Tooltips and ARIA Labels on Material UI IconButtons
+**Learning:** Found instances in the backoffice tables (e.g., `programs/page.tsx`) where icon-only `IconButton` elements lacked `aria-label` attributes and tooltip hints, hindering both screen reader accessibility and visual clarity for sighted users.
+**Action:** When implementing tables or lists with action columns, ensure every icon-only `IconButton` is wrapped in a `<Tooltip>` with a descriptive `title` and directly receives an `aria-label` in Spanish reflecting its action (e.g., 'Editar programa').

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import {
   Box,
+  Tooltip,
   Button,
   Paper,
   Table,
@@ -343,11 +344,17 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa">
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa">
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas">
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 **What**: Added `Tooltip` wrappers and descriptive `aria-label`s to the `IconButton` elements used for "Editar", "Eliminar", and "Gestionar panelistas" in the Backoffice Programs table.
🎯 **Why**: Icon-only buttons lacking accessible names or tooltips pose usability issues for screen-reader users who cannot deduce their purpose, and they lack clarity for sighted users who need hover text to confirm their action.
📸 **Before/After**: Before, the edit/delete/group icons simply triggered actions without any on-hover clues or hidden text. After, hovering reveals "Editar programa", "Eliminar programa", and "Gestionar panelistas" and screen readers will announce those strings when focused.
♿ **Accessibility**: Enhanced `aria-label` tags explicitly map the buttons' visual intent into the accessibility tree.

---
*PR created automatically by Jules for task [10427844376340122293](https://jules.google.com/task/10427844376340122293) started by @matiasrozenblum*