### PR TITLE
🎨 Palette: Add Tooltips and ARIA labels to backoffice action buttons

### DIFF
--- a/src/app/backoffice/channels/page.tsx
+++ b/src/app/backoffice/channels/page.tsx
@@ -16,6 +16,7 @@ import {
   Typography,
   IconButton,
   Dialog,
+  Tooltip,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -382,12 +383,20 @@ export default function ChannelsPage() {
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
                     #{idx + 1}
-                    <IconButton size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
-                      <ArrowUpward fontSize="small" />
-                    </IconButton>
-                    <IconButton size="small" onClick={() => handleMoveDown(idx)} disabled={idx === channels.length - 1}>
-                      <ArrowDownward fontSize="small" />
-                    </IconButton>
+                    <Tooltip title="Mover arriba" arrow>
+                      <span>
+                        <IconButton size="small" aria-label="Mover arriba" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
+                          <ArrowUpward fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                    <Tooltip title="Mover abajo" arrow>
+                      <span>
+                        <IconButton size="small" aria-label="Mover abajo" onClick={() => handleMoveDown(idx)} disabled={idx === channels.length - 1}>
+                          <ArrowDownward fontSize="small" />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
                   </Box>
                 </TableCell>
                 <TableCell>
@@ -416,7 +425,11 @@ export default function ChannelsPage() {
                 </TableCell>
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
-                    <IconButton onClick={() => handleOpenDialog(channel)}><EditIcon /></IconButton>
+                    <Tooltip title="Editar canal" arrow>
+                      <IconButton aria-label="Editar canal" onClick={() => handleOpenDialog(channel)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
                     <Switch
                       checked={channel.is_visible}
                       onChange={() => handleToggleVisibility(channel)}
@@ -424,16 +437,24 @@ export default function ChannelsPage() {
                       size="small"
                     />
                     {channel.handle && (
-                      <IconButton
-                        onClick={() => handleClearCache(channel)}
-                        disabled={clearingCache === channel.id}
-                        title="Limpiar caché de estado en vivo"
-                        color="secondary"
-                      >
-                        <RefreshIcon />
-                      </IconButton>
+                      <Tooltip title="Limpiar caché de estado en vivo" arrow>
+                        <span>
+                          <IconButton
+                            aria-label="Limpiar caché de estado en vivo"
+                            onClick={() => handleClearCache(channel)}
+                            disabled={clearingCache === channel.id}
+                            color="secondary"
+                          >
+                            <RefreshIcon />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
                     )}
-                    <IconButton onClick={() => handleDelete(channel.id)}><DeleteIcon /></IconButton>
+                    <Tooltip title="Eliminar canal" arrow>
+                      <IconButton aria-label="Eliminar canal" onClick={() => handleDelete(channel.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 </TableCell>
               </TableRow>

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
   IconButton,
   Dialog,
+  Tooltip,
   DialogTitle,
   DialogContent,
   DialogActions,
@@ -343,11 +344,21 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa" arrow>
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa" arrow>
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas" arrow>
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 What: Added `Tooltip` components and `aria-label`s to action buttons (`IconButton`s) in `src/app/backoffice/channels/page.tsx` and `src/app/backoffice/programs/page.tsx`. Wrapped disabled icon buttons inside Tooltips with `<span>`s.
🎯 Why: Icon-only buttons without an explicit label or hover context are confusing and fail to convey their purpose to both sighted users and screen readers.
📸 Before/After: Sighted users will now see helpful tooltips (e.g. "Editar canal", "Mover arriba") when hovering over these icons.
♿ Accessibility: Screen readers will now accurately announce the purpose of these buttons using the added `aria-label`s (e.g. "Eliminar programa"). Ensuring tooltips function for disabled buttons also conforms to best UX practices.

---
*PR created automatically by Jules for task [3825448190485717422](https://jules.google.com/task/3825448190485717422) started by @matiasrozenblum*