### PR TITLE
🎨 Palette: Add ARIA labels to action icon buttons in WeeklyOverridesTable

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2024-03-24 - Missing ARIA Labels on Icon Buttons in Tables
+**Learning:** Found an accessibility pattern where action icon buttons (like Edit/Delete) inside data tables (`WeeklyOverridesTable`) lacked `aria-label` attributes, making them inaccessible to screen readers.
+**Action:** Always verify that every `IconButton` component has a descriptive `aria-label` in Spanish, particularly for repeated actions inside tables or lists.

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1165,10 +1165,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <IconButton onClick={() => handleEdit(override)} color="primary">
+                            <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
                               <Edit />
                             </IconButton>
-                            <IconButton onClick={() => handleDelete(override.id)} color="error">
+                            <IconButton aria-label="Eliminar" onClick={() => handleDelete(override.id)} color="error">
                               <Delete />
                             </IconButton>
                           </Box>


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` attributes to the "Editar" and "Eliminar" `IconButton` components inside the `WeeklyOverridesTable`.

### 🎯 Why
Icon-only buttons without `aria-label`s are inaccessible to screen reader users because there is no text context for the action. Adding these labels ensures visually impaired administrators can understand and use the edit and delete actions within the table.

### 📸 Before/After
*N/A - This is an invisible accessibility change.*

### ♿ Accessibility
*   Fixed a missing accessible name violation for icon buttons inside the table row actions.
*   Labels provided in Spanish ("Editar", "Eliminar") for consistency with the application's language.

---
*PR created automatically by Jules for task [7142563492221368934](https://jules.google.com/task/7142563492221368934) started by @matiasrozenblum*