### PR TITLE
🎨 Palette: Add missing ARIA labels to backoffice tables

### DIFF
--- a/src/app/backoffice/banners/page.tsx
+++ b/src/app/backoffice/banners/page.tsx
@@ -449,6 +449,7 @@ export default function BannersPage() {
                       />
                       <Box>
                         <IconButton
+                          aria-label="Editar banner"
                           size="small"
                           onClick={() => handleOpenDialog(banner)}
                           color="primary"
@@ -456,6 +457,7 @@ export default function BannersPage() {
                           <EditIcon />
                         </IconButton>
                         <IconButton
+                          aria-label="Eliminar banner"
                           size="small"
                           onClick={() => setDeleteConfirm({ open: true, banner })}
                           color="error"

--- a/src/app/backoffice/channels/page.tsx
+++ b/src/app/backoffice/channels/page.tsx
@@ -382,10 +382,10 @@ export default function ChannelsPage() {
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
                     #{idx + 1}
-                    <IconButton size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
+                    <IconButton aria-label="Mover arriba" size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
                       <ArrowUpward fontSize="small" />
                     </IconButton>
-                    <IconButton size="small" onClick={() => handleMoveDown(idx)} disabled={idx === channels.length - 1}>
+                    <IconButton aria-label="Mover abajo" size="small" onClick={() => handleMoveDown(idx)} disabled={idx === channels.length - 1}>
                       <ArrowDownward fontSize="small" />
                     </IconButton>
                   </Box>
@@ -416,7 +416,7 @@ export default function ChannelsPage() {
                 </TableCell>
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
-                    <IconButton onClick={() => handleOpenDialog(channel)}><EditIcon /></IconButton>
+                    <IconButton aria-label="Editar canal" onClick={() => handleOpenDialog(channel)}><EditIcon /></IconButton>
                     <Switch
                       checked={channel.is_visible}
                       onChange={() => handleToggleVisibility(channel)}
@@ -433,7 +433,7 @@ export default function ChannelsPage() {
                         <RefreshIcon />
                       </IconButton>
                     )}
-                    <IconButton onClick={() => handleDelete(channel.id)}><DeleteIcon /></IconButton>
+                    <IconButton aria-label="Eliminar canal" onClick={() => handleDelete(channel.id)}><DeleteIcon /></IconButton>
                   </Box>
                 </TableCell>
               </TableRow>

--- a/src/app/backoffice/layout.tsx
+++ b/src/app/backoffice/layout.tsx
@@ -149,6 +149,7 @@ export default function BackofficeLayout({ children }: { children: React.ReactNo
       >
         <Toolbar>
           <IconButton 
+            aria-label="Abrir menú"
             color="inherit" 
             edge="start" 
             onClick={() => setMobileOpen(o => !o)}

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -343,9 +343,9 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                    <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
+                    <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
+                    <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
                       <GroupIcon />
                     </IconButton>
                   </TableCell>

--- a/src/app/backoffice/streamers/page.tsx
+++ b/src/app/backoffice/streamers/page.tsx
@@ -514,11 +514,11 @@ export default function StreamersPage() {
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={1}>
                     #{idx + 1}
-                    <IconButton size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
+                    <IconButton aria-label="Mover arriba" size="small" onClick={() => handleMoveUp(idx)} disabled={idx === 0}>
                       {/* using a simple caret by unicode to avoid extra imports */}
                       <span style={{ fontSize: 14 }}>▲</span>
                     </IconButton>
-                    <IconButton size="small" onClick={() => handleMoveDown(idx)} disabled={idx === streamers.length - 1}>
+                    <IconButton aria-label="Mover abajo" size="small" onClick={() => handleMoveDown(idx)} disabled={idx === streamers.length - 1}>
                       <span style={{ fontSize: 14 }}>▼</span>
                     </IconButton>
                   </Box>
@@ -571,6 +571,7 @@ export default function StreamersPage() {
                 <TableCell>
                   <Box display="flex" gap={0.5}>
                     <IconButton
+                      aria-label="Sincronizar Kick"
                       size="small"
                       onClick={() => handleSyncLiveStatus(streamer.id, 'kick')}
                       disabled={!hasService(streamer, StreamingService.KICK) || syncingService?.streamerId === streamer.id}
@@ -597,6 +598,7 @@ export default function StreamersPage() {
                       )}
                     </IconButton>
                     <IconButton
+                      aria-label="Sincronizar Twitch"
                       size="small"
                       onClick={() => handleSyncLiveStatus(streamer.id, 'twitch')}
                       disabled={!hasService(streamer, StreamingService.TWITCH) || syncingService?.streamerId === streamer.id}
@@ -625,8 +627,8 @@ export default function StreamersPage() {
                   </Box>
                 </TableCell>
                 <TableCell>
-                  <IconButton onClick={() => handleOpenDialog(streamer)}><EditIcon /></IconButton>
-                  <IconButton onClick={() => handleDelete(streamer.id)}><DeleteIcon /></IconButton>
+                  <IconButton aria-label="Editar streamer" onClick={() => handleOpenDialog(streamer)}><EditIcon /></IconButton>
+                  <IconButton aria-label="Eliminar streamer" onClick={() => handleDelete(streamer.id)}><DeleteIcon /></IconButton>
                 </TableCell>
               </TableRow>
             ))}
@@ -761,6 +763,7 @@ export default function StreamersPage() {
                       />
                     ) : null}
                     <IconButton
+                      aria-label="Eliminar servicio"
                       onClick={() => handleRemoveService(index)}
                       color="error"
                       sx={{ mt: 1 }}

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1165,10 +1165,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <IconButton onClick={() => handleEdit(override)} color="primary">
+                            <IconButton aria-label="Editar override" onClick={() => handleEdit(override)} color="primary">
                               <Edit />
                             </IconButton>
-                            <IconButton onClick={() => handleDelete(override.id)} color="error">
+                            <IconButton aria-label="Eliminar override" onClick={() => handleDelete(override.id)} color="error">
                               <Delete />
                             </IconButton>
                           </Box>


### PR DESCRIPTION
💡 **What**: Added descriptive `aria-label` attributes to previously unlabeled icon-only `<IconButton>` components across the backoffice pages (Programs, Channels, Streamers, Banners, Overrides, and Layout).

🎯 **Why**: To improve accessibility for screen readers navigating the admin dashboard, ensuring users without vision can identify the action triggered by an icon (e.g., "Editar", "Eliminar", "Mover arriba").

♿ **Accessibility**: Icon-only buttons must have an explicit `aria-label` description per Material UI guidelines and the project's UX directive. This PR addresses those instances specifically where they were entirely missing.

---
*PR created automatically by Jules for task [2501789721638296912](https://jules.google.com/task/2501789721638296912) started by @matiasrozenblum*