### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2025-05-09 - Missing ARIA Labels on Icon Buttons
+**Learning:** Found missing `aria-label`s on icon-only buttons (`IconButton`) across different components like `StreamersClient` and `WeeklyOverridesTable` where they are used for functional actions like subscribing, editing, or deleting.
+**Action:** Always ensure all icon-only action buttons across the codebase have dynamic or static `aria-label` attributes in Spanish to accurately reflect the action to screen readers.

--- a/src/components/StreamersClient.tsx
+++ b/src/components/StreamersClient.tsx
@@ -623,6 +623,7 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
                           {/* Subscription Button */}
                           <Tooltip title={streamer.is_subscribed ? "Desuscribirse" : "Suscribirse"}>
                             <IconButton
+                              aria-label={streamer.is_subscribed ? "Desuscribirse" : "Suscribirse"}
                               className="subscription-button"
                               onClick={(e) => handleToggleSubscription(e, streamer)}
                               disabled={subscriptionLoading[streamer.id]}

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1165,10 +1165,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <IconButton onClick={() => handleEdit(override)} color="primary">
+                            <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
                               <Edit />
                             </IconButton>
-                            <IconButton onClick={() => handleDelete(override.id)} color="error">
+                            <IconButton aria-label="Eliminar" onClick={() => handleDelete(override.id)} color="error">
                               <Delete />
                             </IconButton>
                           </Box>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to icon-only buttons in `StreamersClient` and `WeeklyOverridesTable` components.
🎯 Why: Without these labels, screen readers do not announce the purpose of the buttons (like "Subscribe", "Edit", or "Delete"), severely limiting accessibility.
♿ Accessibility: Improved screen reader announcements for key interactive elements in the application.

---
*PR created automatically by Jules for task [497528933077979155](https://jules.google.com/task/497528933077979155) started by @matiasrozenblum*