### PR TITLE
🎨 Palette: Add tooltips to password visibility toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2025-02-18 - Missing Tooltips on Password Visibility Toggles
+**Learning:** Found an accessibility pattern where icon-only buttons for toggling password visibility had `aria-label`s, but no visual indicators for sighted users.
+**Action:** Always ensure that icon-only buttons, especially functional ones like password toggles, are wrapped in a `<Tooltip>` that matches their `aria-label` to provide visual context for sighted users.

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -7,6 +7,7 @@ import {
   AlertTitle,
   InputAdornment,
   IconButton,
+  Tooltip,
   Typography,
   CircularProgress
 } from '@mui/material';
@@ -94,14 +95,16 @@ export default function ExistingUserStep({
           ),
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton
-                aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                onClick={() => setShow(s => !s)}
-                edge="end"
-                size="small"
-              >
-                {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-              </IconButton>
+              <Tooltip title={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}>
+                <IconButton
+                  aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  onClick={() => setShow(s => !s)}
+                  edge="end"
+                  size="small"
+                >
+                  {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
             </InputAdornment>
           )
         }}

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -7,6 +7,7 @@ import {
   AlertTitle,
   InputAdornment,
   IconButton,
+  Tooltip,
   LinearProgress,
   Typography,
   CircularProgress
@@ -87,13 +88,15 @@ export default function PasswordStep({
           ),
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton
-                aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                size="small"
-                onClick={() => setShow(s => !s)}
-              >
-                {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-              </IconButton>
+              <Tooltip title={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}>
+                <IconButton
+                  aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  size="small"
+                  onClick={() => setShow(s => !s)}
+                >
+                  {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
             </InputAdornment>
           )
         }}
@@ -119,13 +122,15 @@ export default function PasswordStep({
           ),
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton
-                aria-label={show2 ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                size="small"
-                onClick={() => setShow2(s => !s)}
-              >
-                {show2 ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-              </IconButton>
+              <Tooltip title={show2 ? 'Ocultar contraseña' : 'Mostrar contraseña'}>
+                <IconButton
+                  aria-label={show2 ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  size="small"
+                  onClick={() => setShow2(s => !s)}
+                >
+                  {show2 ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
             </InputAdornment>
           )
         }}


### PR DESCRIPTION
💡 What: Wrapped the password visibility toggle icon buttons in `ExistingUserStep.tsx` and `PasswordStep.tsx` with Material-UI `<Tooltip>` components.
🎯 Why: To improve the user experience for sighted users by providing a visual explanation of the button's action on hover or focus, matching the existing `aria-label`.
♿ Accessibility: The tooltips provide a clear visual indicator of the state ("Mostrar contraseña" / "Ocultar contraseña") alongside the icon change, ensuring parity between visual and screen reader experiences.

---
*PR created automatically by Jules for task [2135428737823008062](https://jules.google.com/task/2135428737823008062) started by @matiasrozenblum*