### PR TITLE
🎨 Palette: Add missing ARIA labels to WeeklyOverridesTable icon buttons

### DIFF
--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1165,10 +1165,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Box sx={{ display: 'flex', gap: 1 }}>
-                            <IconButton onClick={() => handleEdit(override)} color="primary">
+                            <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
                               <Edit />
                             </IconButton>
-                            <IconButton onClick={() => handleDelete(override.id)} color="error">
+                            <IconButton aria-label="Eliminar" onClick={() => handleDelete(override.id)} color="error">
                               <Delete />
                             </IconButton>
                           </Box>


### PR DESCRIPTION
💡 **What**: Added `aria-label`s to the missing edit/delete `IconButton`s in the WeeklyOverridesTable backoffice component.

🎯 **Why**: Improves accessibility for screen reader users by properly tagging these icon-only buttons. The system previously lacked descriptive text for these two specific functional icons.

♿ **Accessibility**: Adds `aria-label="Editar"` and `aria-label="Eliminar"` matching existing patterns.

---
*PR created automatically by Jules for task [4643169323745110162](https://jules.google.com/task/4643169323745110162) started by @matiasrozenblum*