### PR TITLE
🎨 Palette: Add Tooltips and ARIA labels to Programs backoffice actions

### DIFF
--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   FormControlLabel,
   Checkbox,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -343,11 +344,21 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar">
+                      <IconButton aria-label="Editar" onClick={() => handleOpenDialog(program)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar">
+                      <IconButton aria-label="Eliminar" onClick={() => handleDelete(program.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas">
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 **What:** Added `aria-label`s and `<Tooltip>` wrappers to the action buttons (Edit, Delete, Manage Panelists) in the Programs backoffice table.
🎯 **Why:** To improve accessibility for screen readers (which could not discern the purpose of the icon-only buttons) and provide immediate context to mouse/pointer users via tooltips.
📸 **Before/After:** Not applicable since it's an accessibility/interaction enhancement, but hovering over the buttons will now show a descriptive tooltip in Spanish.
♿ **Accessibility:** Screen readers will now announce "Editar", "Eliminar", and "Gestionar panelistas" respectively.

---
*PR created automatically by Jules for task [4829572111843390533](https://jules.google.com/task/4829572111843390533) started by @matiasrozenblum*