### PR TITLE
🎨 Palette: Add Tooltips and ARIA labels to action buttons in backoffice programs page

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2025-02-18 - Added Tooltips to Action IconButtons
+**Learning:** Icon-only buttons used for table row actions in backoffice pages (Edit, Delete, Manage) often lack `aria-label` attributes and tooltip context, hindering accessibility and usability.
+**Action:** When creating or maintaining lists/tables with action icons, wrap `IconButton` components with MUI's `<Tooltip>` and define explicit, descriptive `aria-label`s in Spanish to ensure accessibility.

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -13,6 +13,7 @@ import {
   TableRow,
   Typography,
   IconButton,
+  Tooltip,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -343,11 +344,21 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa">
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa">
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas">
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 **What:** Added MUI `Tooltip` components and descriptive `aria-label`s in Spanish to the "Edit", "Delete", and "Manage Panelists" icon-only buttons in the backoffice programs table.
🎯 **Why:** To improve accessibility for screen readers and provide better visual context for sighted users when hovering over action icons in the admin interface.
📸 **Before/After:** No visual layout change, but tooltips are now visible on hover.
♿ **Accessibility:** Screen readers now announce the exact action of these buttons ("Editar programa", "Eliminar programa", "Gestionar panelistas") rather than just reading generic element types.

---
*PR created automatically by Jules for task [2499252549483307854](https://jules.google.com/task/2499252549483307854) started by @matiasrozenblum*