### PR TITLE
🎨 Palette: Add Tooltips and ARIA labels to backoffice programs actions

### DIFF
--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   FormControlLabel,
   Checkbox,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -343,11 +344,21 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa" arrow>
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}>
+                        <EditIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa" arrow>
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}>
+                        <DeleteIcon />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas" arrow>
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 **What**: Added `<Tooltip>` wrappers and `aria-label` attributes to the Edit, Delete, and Group actions within the Programs table in the backoffice.

🎯 **Why**: These were icon-only buttons with no accessible names or visual explanations for mouse hover, breaking accessibility standards and making the interface less intuitive.

📸 **Before/After**: Visually, the icons remain identical, but hovering over them now displays descriptive text ("Editar programa", "Eliminar programa", "Gestionar panelistas").

♿ **Accessibility**: 
- Added `aria-label` in Spanish for each icon button.
- The wrapping `<Tooltip>` adds ARIA descriptive support natively through Material UI for screen readers, and visual feedback for users navigating with a mouse.

---
*PR created automatically by Jules for task [4049843921677285921](https://jules.google.com/task/4049843921677285921) started by @matiasrozenblum*