### PR TITLE
🎨 Palette: [a11y/UX] Add tooltips and aria-labels to backoffice program actions

### DIFF
--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   FormControlLabel,
   Checkbox,
+  Tooltip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -343,11 +344,17 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
-                      <GroupIcon />
-                    </IconButton>
+                    <Tooltip title="Editar programa" arrow>
+                      <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar programa" arrow>
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
+                    </Tooltip>
+                    <Tooltip title="Gestionar panelistas" arrow>
+                      <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                        <GroupIcon />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               );


### PR DESCRIPTION
💡 **What**: Added `Tooltip` components and `aria-label` attributes to the Edit, Delete, and Manage Panelists icon-only buttons (`IconButton`) in the backoffice programs grid (`src/app/backoffice/programs/page.tsx`).
🎯 **Why**: To improve the accessibility and user experience of icon-only buttons. Screen readers now have descriptive text in Spanish, and sighted users receive contextual tooltips on hover.
📸 **Before/After**: Visually unchanged aside from new hover tooltips.
♿ **Accessibility**: Icon buttons now have `aria-label`s ('Editar programa', 'Eliminar programa', 'Gestionar panelistas') allowing assistive technologies to announce their functionality correctly.

---
*PR created automatically by Jules for task [10427969610237346645](https://jules.google.com/task/10427969610237346645) started by @matiasrozenblum*