### PR TITLE
🎨 Palette: Añadir aria-labels a IconButtons en listado de programas

### DIFF
--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -343,9 +343,9 @@ export default function ProgramsPage() {
                   </TableCell>
                   <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
-                    <IconButton onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
-                    <IconButton onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
-                    <IconButton onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
+                    <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
+                    <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
+                    <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
                       <GroupIcon />
                     </IconButton>
                   </TableCell>


### PR DESCRIPTION
💡 What: Se añadieron `aria-label`s descriptivos en español ("Editar programa", "Eliminar programa", "Gestionar panelistas") a los `IconButton`s dentro de la tabla en `src/app/backoffice/programs/page.tsx`.
🎯 Why: Los botones que solo contienen iconos resultan ininteligibles para los usuarios de lectores de pantalla ("botón, botón, botón"). Proveer un `aria-label` mejora drásticamente la accesibilidad.
📸 Before/After: Visualmente no hay cambios.
♿ Accessibility: Mejora directa para usuarios que dependen de tecnologías de asistencia en el panel de administración.

---
*PR created automatically by Jules for task [8673135692073935761](https://jules.google.com/task/8673135692073935761) started by @matiasrozenblum*