### PR TITLE
🎨 Palette: Añadir Tooltip y ARIA label en español a botón eliminar dispositivo

### DIFF
--- a/src/components/backoffice/ManageDevicesDialog.tsx
+++ b/src/components/backoffice/ManageDevicesDialog.tsx
@@ -12,6 +12,7 @@ import {
   ListItem,
   ListItemText,
   Alert,
+  Tooltip,
 } from '@mui/material';
 import { Delete } from '@mui/icons-material';
 import { User } from '@/types/user';
@@ -88,9 +89,11 @@ export function ManageDevicesDialog({ open, onClose, user, session, onDeviceDele
                 <ListItem
                   key={device.id}
                   secondaryAction={
-                    <IconButton edge="end" aria-label="delete" onClick={() => handleDeleteDevice(device.id)}>
-                      <Delete />
-                    </IconButton>
+                    <Tooltip title="Eliminar dispositivo">
+                      <IconButton edge="end" aria-label="Eliminar dispositivo" onClick={() => handleDeleteDevice(device.id)}>
+                        <Delete />
+                      </IconButton>
+                    </Tooltip>
                   }
                 >
                   <ListItemText


### PR DESCRIPTION
### 💡 What
- Added a `<Tooltip title="Eliminar dispositivo">` to the `Delete` `IconButton` in `ManageDevicesDialog.tsx`.
- Changed the `aria-label` on the `IconButton` from `"delete"` to `"Eliminar dispositivo"`.

### 🎯 Why
- Provide sighted users with clear guidance on what the trash icon does (especially considering destructive actions like deleting devices).
- Improve accessibility for screen-reader users by translating the generic english label to an appropriate, more descriptive localized label in Spanish.

### ♿ Accessibility
- Enhanced ARIA labelling specifically tailored to Spanish screen reader profiles and precise action description.
- Improved focus/hover visual context via `Tooltip`.

---
*PR created automatically by Jules for task [17018537058722720470](https://jules.google.com/task/17018537058722720470) started by @matiasrozenblum*