### PR TITLE
feat: monthly schedule recurrence UI in backoffice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+---
+
+## [1.18.0] - 2026-05-24
+
 ### Added
 - Monthly schedule recurrence UI in backoffice (`SchedulesTable`): "Tipo de recurrencia" selector with three modes — Semanal, Mensual fijo, Mensual por fecha
 - "Mensual fijo": shows week-of-month picker (1°–4°, Último) + day-of-week picker
 - "Mensual por fecha": shows date picker + informational alert to load each date manually
 - "Horarios Actuales" table: new Tipo chip column and unified Día / Fecha column supporting all three recurrence types
 - Inline edit row in the schedule table supports switching and editing all three recurrence types
-
-### Changed
-
-### Removed
+- Monthly schedule recurrence UI in "Editar Programa" dialog (`ProgramSchedulesSection`): same recurrence modes available when adding/editing schedules from the program edit flow
+- TypeScript types updated: `schedule_type`, `week_number_in_month`, `specific_date` added to `Schedule` interface
 
 ### Fixed
+- "Agregar Horario" button no longer overflows the dialog on narrow screens (moved to its own full-width row below the time fields), in both `SchedulesTable` and `ProgramSchedulesSection`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ## [Unreleased]
 
 ### Added
+- Monthly schedule recurrence UI in backoffice (`SchedulesTable`): "Tipo de recurrencia" selector with three modes — Semanal, Mensual fijo, Mensual por fecha
+- "Mensual fijo": shows week-of-month picker (1°–4°, Último) + day-of-week picker
+- "Mensual por fecha": shows date picker + informational alert to load each date manually
+- "Horarios Actuales" table: new Tipo chip column and unified Día / Fecha column supporting all three recurrence types
+- Inline edit row in the schedule table supports switching and editing all three recurrence types
 
 ### Changed
 

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -45,9 +45,12 @@ import type { SessionWithToken } from '@/types/session';
 
 interface PendingSchedule {
   id: string;
-  dayOfWeek: string;
+  dayOfWeek?: string;
   startTime: string;
   endTime: string;
+  scheduleType: string;
+  weekNumberInMonth?: string;
+  specificDate?: string;
 }
 
 export default function ProgramsPage() {
@@ -183,9 +186,12 @@ export default function ProgramsPage() {
             programId: newProgramId.toString(),
             channelId: channelId.toString(),
             schedules: pendingSchedules.map(s => ({
-              dayOfWeek: s.dayOfWeek,
               startTime: s.startTime,
               endTime: s.endTime,
+              scheduleType: s.scheduleType || 'weekly',
+              ...(s.dayOfWeek && { dayOfWeek: s.dayOfWeek }),
+              ...(s.weekNumberInMonth && { weekNumberInMonth: parseInt(s.weekNumberInMonth, 10) }),
+              ...(s.specificDate && { specificDate: s.specificDate }),
             })),
           };
           

--- a/src/components/backoffice/ProgramSchedulesSection.tsx
+++ b/src/components/backoffice/ProgramSchedulesSection.tsx
@@ -25,7 +25,10 @@ import {
   ListItem,
   ListItemText,
   ListItemSecondaryAction,
+  Alert,
+  Chip,
 } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import {
   Edit,
   Delete,
@@ -58,6 +61,31 @@ const DAYS_OF_WEEK = [
   { value: 'sunday', label: 'Domingo' },
 ] as const;
 
+const SCHEDULE_TYPES = [
+  { value: 'weekly', label: 'Semanal' },
+  { value: 'monthly_weekday', label: 'Mensual fijo' },
+  { value: 'monthly_dated', label: 'Mensual por fecha' },
+] as const;
+
+const WEEK_NUMBERS = [
+  { value: 1, label: '1°' },
+  { value: 2, label: '2°' },
+  { value: 3, label: '3°' },
+  { value: 4, label: '4°' },
+  { value: -1, label: 'Último' },
+] as const;
+
+const formatScheduleLabel = (schedule: ScheduleType): string => {
+  const type = schedule.schedule_type || 'weekly';
+  if (type === 'monthly_weekday') {
+    const weekLabel = WEEK_NUMBERS.find(w => w.value === schedule.week_number_in_month)?.label || '';
+    const dayLabel = DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week || '';
+    return `${weekLabel} ${dayLabel} de cada mes`;
+  }
+  if (type === 'monthly_dated') return schedule.specific_date || '-';
+  return DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week || '-';
+};
+
 type DayOfWeek = typeof DAYS_OF_WEEK[number]['value'];
 
 interface BulkScheduleData {
@@ -68,9 +96,12 @@ interface BulkScheduleData {
 
 interface PendingSchedule {
   id: string; // Temporary ID for new schedules
-  dayOfWeek: DayOfWeek;
+  dayOfWeek?: string;
   startTime: string;
   endTime: string;
+  scheduleType: string;
+  weekNumberInMonth?: string;
+  specificDate?: string;
 }
 
 interface ProgramSchedulesSectionProps {
@@ -90,7 +121,7 @@ export function ProgramSchedulesSection({
   const [schedules, setSchedules] = useState<ScheduleType[]>([]);
   const [pendingSchedules, setPendingSchedules] = useState<PendingSchedule[]>([]);
   const [editingSchedule, setEditingSchedule] = useState<ScheduleType | null>(null);
-  const [formData, setFormData] = useState({ dayOfWeek: '', startTime: '', endTime: '' });
+  const [formData, setFormData] = useState({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
   const [bulkSchedules, setBulkSchedules] = useState<BulkScheduleData[]>([]);
   const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
   const [bulkTimeRange, setBulkTimeRange] = useState({ startTime: '', endTime: '' });
@@ -159,25 +190,31 @@ export function ProgramSchedulesSection({
   const handleOpenEditDialog = (schedule: ScheduleType) => {
     setEditingSchedule(schedule);
     setFormData({
-      dayOfWeek: schedule.day_of_week,
+      dayOfWeek: schedule.day_of_week || '',
       startTime: schedule.start_time,
       endTime: schedule.end_time,
+      scheduleType: schedule.schedule_type || 'weekly',
+      weekNumberInMonth: schedule.week_number_in_month?.toString() || '',
+      specificDate: schedule.specific_date || '',
     });
   };
 
   const handleCloseEditDialog = () => {
     setEditingSchedule(null);
-    setFormData({ dayOfWeek: '', startTime: '', endTime: '' });
+    setFormData({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
   };
 
   const handleUpdateSchedule = async () => {
     if (!editingSchedule || !programId || !typedSession?.accessToken) return;
     
     try {
-      const updateData = {
-        dayOfWeek: formData.dayOfWeek,
+      const updateData: Record<string, unknown> = {
         startTime: formData.startTime,
         endTime: formData.endTime,
+        scheduleType: formData.scheduleType,
+        ...(formData.scheduleType !== 'monthly_dated' && { dayOfWeek: formData.dayOfWeek }),
+        ...(formData.scheduleType === 'monthly_weekday' && formData.weekNumberInMonth && { weekNumberInMonth: parseInt(formData.weekNumberInMonth, 10) }),
+        ...(formData.scheduleType === 'monthly_dated' && formData.specificDate && { specificDate: formData.specificDate }),
       };
       const response = await api.put<ScheduleType>(
         `/schedules/${editingSchedule.id}`,
@@ -211,8 +248,21 @@ export function ProgramSchedulesSection({
   };
 
   const handleAddSchedule = async () => {
-    if (!formData.dayOfWeek || !formData.startTime || !formData.endTime) {
-      setError('Todos los campos son requeridos');
+    const type = formData.scheduleType;
+    if (!formData.startTime || !formData.endTime) {
+      setError('Los campos de horario son requeridos');
+      return;
+    }
+    if ((type === 'weekly' || type === 'monthly_weekday') && !formData.dayOfWeek) {
+      setError('El día de la semana es requerido');
+      return;
+    }
+    if (type === 'monthly_weekday' && !formData.weekNumberInMonth) {
+      setError('La semana del mes es requerida');
+      return;
+    }
+    if (type === 'monthly_dated' && !formData.specificDate) {
+      setError('La fecha específica es requerida');
       return;
     }
 
@@ -224,12 +274,15 @@ export function ProgramSchedulesSection({
       }
       const newPending: PendingSchedule = {
         id: `pending-${Date.now()}-${Math.random()}`,
-        dayOfWeek: formData.dayOfWeek as DayOfWeek,
         startTime: formData.startTime,
         endTime: formData.endTime,
+        scheduleType: type,
+        ...(type !== 'monthly_dated' && { dayOfWeek: formData.dayOfWeek }),
+        ...(type === 'monthly_weekday' && { weekNumberInMonth: formData.weekNumberInMonth }),
+        ...(type === 'monthly_dated' && { specificDate: formData.specificDate }),
       };
       setPendingSchedules([...pendingSchedules, newPending]);
-      setFormData({ dayOfWeek: '', startTime: '', endTime: '' });
+      setFormData({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
       setSuccess('Horario agregado (se creará al guardar el programa)');
       return;
     }
@@ -241,19 +294,22 @@ export function ProgramSchedulesSection({
     }
 
     try {
-      const newData = {
+      const newData: Record<string, unknown> = {
         programId: programId.toString(),
         channelId: channelId.toString(),
-        dayOfWeek: formData.dayOfWeek,
         startTime: formData.startTime,
         endTime: formData.endTime,
+        scheduleType: type,
+        ...(type !== 'monthly_dated' && { dayOfWeek: formData.dayOfWeek }),
+        ...(type === 'monthly_weekday' && { weekNumberInMonth: parseInt(formData.weekNumberInMonth, 10) }),
+        ...(type === 'monthly_dated' && { specificDate: formData.specificDate }),
       };
       const response = await api.post<ScheduleType>('/schedules', newData, {
         headers: { Authorization: `Bearer ${typedSession.accessToken}` },
       });
       const created = response.data;
       setSchedules([...schedules, created]);
-      setFormData({ dayOfWeek: '', startTime: '', endTime: '' });
+      setFormData({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
       setSuccess('Horario agregado correctamente');
     } catch (err) {
       console.error('Error adding schedule:', err);
@@ -269,9 +325,12 @@ export function ProgramSchedulesSection({
     const schedule = pendingSchedules.find(s => s.id === id);
     if (schedule) {
       setFormData({
-        dayOfWeek: schedule.dayOfWeek,
+        dayOfWeek: schedule.dayOfWeek || '',
         startTime: schedule.startTime,
         endTime: schedule.endTime,
+        scheduleType: schedule.scheduleType || 'weekly',
+        weekNumberInMonth: schedule.weekNumberInMonth || '',
+        specificDate: schedule.specificDate || '',
       });
       handleDeletePendingSchedule(id);
     }
@@ -293,6 +352,7 @@ export function ProgramSchedulesSection({
       // Add to pending schedules
       const newPending: PendingSchedule[] = newSchedules.map((s, idx) => ({
         id: `pending-bulk-${Date.now()}-${idx}`,
+        scheduleType: 'weekly',
         ...s,
       }));
       setPendingSchedules([...pendingSchedules, ...newPending]);
@@ -405,7 +465,8 @@ export function ProgramSchedulesSection({
                 <Table size="small">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Día</TableCell>
+                      <TableCell>Tipo</TableCell>
+                      <TableCell>Día / Fecha</TableCell>
                       <TableCell>Inicio</TableCell>
                       <TableCell>Fin</TableCell>
                       <TableCell>Acciones</TableCell>
@@ -419,17 +480,54 @@ export function ProgramSchedulesSection({
                             <TableCell>
                               <TextField
                                 select
-                                value={formData.dayOfWeek}
-                                onChange={(e) => setFormData({ ...formData, dayOfWeek: e.target.value })}
+                                value={formData.scheduleType}
+                                onChange={(e) => setFormData({ ...formData, scheduleType: e.target.value })}
                                 size="small"
                                 fullWidth
                               >
-                                {DAYS_OF_WEEK.map((day) => (
-                                  <MenuItem key={day.value} value={day.value}>
-                                    {day.label}
-                                  </MenuItem>
+                                {SCHEDULE_TYPES.map((t) => (
+                                  <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
                                 ))}
                               </TextField>
+                            </TableCell>
+                            <TableCell>
+                              {formData.scheduleType === 'monthly_dated' ? (
+                                <TextField
+                                  type="date"
+                                  value={formData.specificDate}
+                                  onChange={(e) => setFormData({ ...formData, specificDate: e.target.value })}
+                                  InputLabelProps={{ shrink: true }}
+                                  size="small"
+                                  fullWidth
+                                />
+                              ) : (
+                                <Box sx={{ display: 'flex', gap: 1 }}>
+                                  {formData.scheduleType === 'monthly_weekday' && (
+                                    <TextField
+                                      select
+                                      value={formData.weekNumberInMonth}
+                                      onChange={(e) => setFormData({ ...formData, weekNumberInMonth: e.target.value })}
+                                      size="small"
+                                      sx={{ minWidth: 75 }}
+                                    >
+                                      {WEEK_NUMBERS.map((w) => (
+                                        <MenuItem key={w.value} value={w.value.toString()}>{w.label}</MenuItem>
+                                      ))}
+                                    </TextField>
+                                  )}
+                                  <TextField
+                                    select
+                                    value={formData.dayOfWeek}
+                                    onChange={(e) => setFormData({ ...formData, dayOfWeek: e.target.value })}
+                                    size="small"
+                                    fullWidth
+                                  >
+                                    {DAYS_OF_WEEK.map((day) => (
+                                      <MenuItem key={day.value} value={day.value}>{day.label}</MenuItem>
+                                    ))}
+                                  </TextField>
+                                </Box>
+                              )}
                             </TableCell>
                             <TableCell>
                               <TextField
@@ -463,8 +561,13 @@ export function ProgramSchedulesSection({
                         ) : (
                           <>
                             <TableCell>
-                              {DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week}
+                              <Chip
+                                label={SCHEDULE_TYPES.find(t => t.value === (schedule.schedule_type || 'weekly'))?.label || 'Semanal'}
+                                size="small"
+                                color={schedule.schedule_type === 'monthly_weekday' ? 'primary' : schedule.schedule_type === 'monthly_dated' ? 'secondary' : 'default'}
+                              />
                             </TableCell>
+                            <TableCell>{formatScheduleLabel(schedule)}</TableCell>
                             <TableCell>{formatTime(schedule.start_time)}</TableCell>
                             <TableCell>{formatTime(schedule.end_time)}</TableCell>
                             <TableCell>
@@ -493,7 +596,8 @@ export function ProgramSchedulesSection({
                 <Table size="small">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Día</TableCell>
+                      <TableCell>Tipo</TableCell>
+                      <TableCell>Día / Fecha</TableCell>
                       <TableCell>Inicio</TableCell>
                       <TableCell>Fin</TableCell>
                       <TableCell>Acciones</TableCell>
@@ -503,7 +607,19 @@ export function ProgramSchedulesSection({
                     {pendingSchedules.map(schedule => (
                       <TableRow key={schedule.id}>
                         <TableCell>
-                          {DAYS_OF_WEEK.find(d => d.value === schedule.dayOfWeek)?.label || schedule.dayOfWeek}
+                          <Chip
+                            label={SCHEDULE_TYPES.find(t => t.value === (schedule.scheduleType || 'weekly'))?.label || 'Semanal'}
+                            size="small"
+                            color={schedule.scheduleType === 'monthly_weekday' ? 'primary' : schedule.scheduleType === 'monthly_dated' ? 'secondary' : 'default'}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          {schedule.scheduleType === 'monthly_dated'
+                            ? schedule.specificDate || '-'
+                            : schedule.scheduleType === 'monthly_weekday'
+                              ? `${WEEK_NUMBERS.find(w => w.value === parseInt(schedule.weekNumberInMonth || '0'))?.label || ''} ${DAYS_OF_WEEK.find(d => d.value === schedule.dayOfWeek)?.label || schedule.dayOfWeek || ''}`
+                              : DAYS_OF_WEEK.find(d => d.value === schedule.dayOfWeek)?.label || schedule.dayOfWeek || '-'
+                          }
                         </TableCell>
                         <TableCell>{formatTime(schedule.startTime)}</TableCell>
                         <TableCell>{formatTime(schedule.endTime)}</TableCell>
@@ -536,47 +652,101 @@ export function ProgramSchedulesSection({
             <Typography variant="h6" sx={{ mb: 2 }}>
               Agregar Horario
             </Typography>
-            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <TextField
                 select
-                label="Día de la semana"
-                value={formData.dayOfWeek}
-                onChange={(e) => setFormData({ ...formData, dayOfWeek: e.target.value })}
+                label="Tipo de recurrencia"
+                value={formData.scheduleType}
+                onChange={(e) => setFormData({ ...formData, scheduleType: e.target.value, dayOfWeek: '', weekNumberInMonth: '', specificDate: '' })}
                 fullWidth
-                sx={{ minWidth: 150 }}
               >
-                {DAYS_OF_WEEK.map((day) => (
-                  <MenuItem key={day.value} value={day.value}>
-                    {day.label}
-                  </MenuItem>
+                {SCHEDULE_TYPES.map((t) => (
+                  <MenuItem key={t.value} value={t.value}>{t.label}</MenuItem>
                 ))}
               </TextField>
-              <TextField
-                label="Hora de inicio"
-                type="time"
-                value={formData.startTime}
-                onChange={(e) => setFormData({ ...formData, startTime: e.target.value })}
-                InputLabelProps={{ shrink: true }}
-                fullWidth
-                sx={{ minWidth: 150 }}
-              />
-              <TextField
-                label="Hora de fin"
-                type="time"
-                value={formData.endTime}
-                onChange={(e) => setFormData({ ...formData, endTime: e.target.value })}
-                InputLabelProps={{ shrink: true }}
-                fullWidth
-                sx={{ minWidth: 150 }}
-              />
-              <Button
-                variant="contained"
-                onClick={handleAddSchedule}
-                startIcon={<Add />}
-                disabled={!formData.dayOfWeek || !formData.startTime || !formData.endTime}
-              >
-                Agregar
-              </Button>
+
+              {formData.scheduleType === 'weekly' && (
+                <TextField
+                  select
+                  label="Día de la semana"
+                  value={formData.dayOfWeek}
+                  onChange={(e) => setFormData({ ...formData, dayOfWeek: e.target.value })}
+                  fullWidth
+                >
+                  {DAYS_OF_WEEK.map((day) => (
+                    <MenuItem key={day.value} value={day.value}>{day.label}</MenuItem>
+                  ))}
+                </TextField>
+              )}
+
+              {formData.scheduleType === 'monthly_weekday' && (
+                <Box sx={{ display: 'flex', gap: 2 }}>
+                  <TextField
+                    select
+                    label="Semana del mes"
+                    value={formData.weekNumberInMonth}
+                    onChange={(e) => setFormData({ ...formData, weekNumberInMonth: e.target.value })}
+                    fullWidth
+                  >
+                    {WEEK_NUMBERS.map((w) => (
+                      <MenuItem key={w.value} value={w.value.toString()}>{w.label}</MenuItem>
+                    ))}
+                  </TextField>
+                  <TextField
+                    select
+                    label="Día de la semana"
+                    value={formData.dayOfWeek}
+                    onChange={(e) => setFormData({ ...formData, dayOfWeek: e.target.value })}
+                    fullWidth
+                  >
+                    {DAYS_OF_WEEK.map((day) => (
+                      <MenuItem key={day.value} value={day.value}>{day.label}</MenuItem>
+                    ))}
+                  </TextField>
+                </Box>
+              )}
+
+              {formData.scheduleType === 'monthly_dated' && (
+                <Box>
+                  <TextField
+                    label="Fecha específica"
+                    type="date"
+                    value={formData.specificDate}
+                    onChange={(e) => setFormData({ ...formData, specificDate: e.target.value })}
+                    InputLabelProps={{ shrink: true }}
+                    fullWidth
+                  />
+                  <Alert severity="info" icon={<InfoOutlinedIcon />} sx={{ mt: 1 }}>
+                    Deberás cargar manualmente cada fecha cuando se confirme.
+                  </Alert>
+                </Box>
+              )}
+
+              <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-end' }}>
+                <TextField
+                  label="Hora de inicio"
+                  type="time"
+                  value={formData.startTime}
+                  onChange={(e) => setFormData({ ...formData, startTime: e.target.value })}
+                  InputLabelProps={{ shrink: true }}
+                  fullWidth
+                />
+                <TextField
+                  label="Hora de fin"
+                  type="time"
+                  value={formData.endTime}
+                  onChange={(e) => setFormData({ ...formData, endTime: e.target.value })}
+                  InputLabelProps={{ shrink: true }}
+                  fullWidth
+                />
+                <Button
+                  variant="contained"
+                  onClick={handleAddSchedule}
+                  startIcon={<Add />}
+                >
+                  Agregar
+                </Button>
+              </Box>
             </Box>
           </Box>
 

--- a/src/components/backoffice/ProgramSchedulesSection.tsx
+++ b/src/components/backoffice/ProgramSchedulesSection.tsx
@@ -722,7 +722,7 @@ export function ProgramSchedulesSection({
                 </Box>
               )}
 
-              <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-end' }}>
+              <Box sx={{ display: 'flex', gap: 2 }}>
                 <TextField
                   label="Hora de inicio"
                   type="time"
@@ -739,14 +739,15 @@ export function ProgramSchedulesSection({
                   InputLabelProps={{ shrink: true }}
                   fullWidth
                 />
-                <Button
-                  variant="contained"
-                  onClick={handleAddSchedule}
-                  startIcon={<Add />}
-                >
-                  Agregar
-                </Button>
               </Box>
+              <Button
+                variant="contained"
+                onClick={handleAddSchedule}
+                startIcon={<Add />}
+                fullWidth
+              >
+                Agregar
+              </Button>
             </Box>
           </Box>
 

--- a/src/components/backoffice/SchedulesTable.tsx
+++ b/src/components/backoffice/SchedulesTable.tsx
@@ -768,14 +768,14 @@ export function SchedulesTable() {
                         InputLabelProps={{ shrink: true }}
                         fullWidth
                       />
-                      <Button
-                        variant="contained"
-                        onClick={handleAddProgramSchedule}
-                        sx={{ alignSelf: 'flex-end' }}
-                      >
-                        Agregar
-                      </Button>
                     </Box>
+                    <Button
+                      variant="contained"
+                      onClick={handleAddProgramSchedule}
+                      fullWidth
+                    >
+                      Agregar
+                    </Button>
                   </Box>
                 </Box>
               )}

--- a/src/components/backoffice/SchedulesTable.tsx
+++ b/src/components/backoffice/SchedulesTable.tsx
@@ -33,12 +33,13 @@ import {
   Checkbox,
   FormControlLabel,
 } from '@mui/material';
-import { 
-  Edit, 
-  Delete, 
-  Add, 
-  Check, 
-  Close, 
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import {
+  Edit,
+  Delete,
+  Add,
+  Check,
+  Close,
   AddCircle,
   Schedule,
 } from '@mui/icons-material';
@@ -65,6 +66,34 @@ const DAYS_OF_WEEK = [
   { value: 'sunday', label: 'Domingo' },
 ] as const;
 
+const SCHEDULE_TYPES = [
+  { value: 'weekly', label: 'Semanal' },
+  { value: 'monthly_weekday', label: 'Mensual fijo' },
+  { value: 'monthly_dated', label: 'Mensual por fecha' },
+] as const;
+
+const WEEK_NUMBERS = [
+  { value: 1, label: '1°' },
+  { value: 2, label: '2°' },
+  { value: 3, label: '3°' },
+  { value: 4, label: '4°' },
+  { value: -1, label: 'Último' },
+] as const;
+
+const formatScheduleLabel = (schedule: ScheduleType): string => {
+  const type = schedule.schedule_type || 'weekly';
+  if (type === 'monthly_weekday') {
+    const weekLabel = WEEK_NUMBERS.find(w => w.value === schedule.week_number_in_month)?.label || '';
+    const dayLabel = DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week || '';
+    return `${weekLabel} ${dayLabel} de cada mes ${formatTime(schedule.start_time)}-${formatTime(schedule.end_time)}`;
+  }
+  if (type === 'monthly_dated') {
+    return `Fecha ${schedule.specific_date || ''} ${formatTime(schedule.start_time)}-${formatTime(schedule.end_time)}`;
+  }
+  const dayLabel = DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week || '';
+  return `${dayLabel} ${formatTime(schedule.start_time)}-${formatTime(schedule.end_time)}`;
+};
+
 type DayOfWeek = typeof DAYS_OF_WEEK[number]['value'];
 
 interface ProgramWithSchedules extends Program {
@@ -86,11 +115,11 @@ export function SchedulesTable() {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedProgram, setSelectedProgram] = useState<ProgramWithSchedules | null>(null);
   const [editingSchedule, setEditingSchedule] = useState<ScheduleType | null>(null);
-  const [formData, setFormData] = useState({ dayOfWeek: '', startTime: '', endTime: '', programId: '' });
+  const [formData, setFormData] = useState({ dayOfWeek: '', startTime: '', endTime: '', programId: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [openProgramDialog, setOpenProgramDialog] = useState(false);
-  const [programFormData, setProgramFormData] = useState({ dayOfWeek: '', startTime: '', endTime: '' });
+  const [programFormData, setProgramFormData] = useState({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
   const [bulkSchedules, setBulkSchedules] = useState<BulkScheduleData[]>([]);
   const [selectedDays, setSelectedDays] = useState<DayOfWeek[]>([]);
   const [bulkTimeRange, setBulkTimeRange] = useState({ startTime: '', endTime: '' });
@@ -142,25 +171,31 @@ export function SchedulesTable() {
   const handleOpenEditDialog = (schedule: ScheduleType) => {
     setEditingSchedule(schedule);
     setFormData({
-      dayOfWeek: schedule.day_of_week,
+      dayOfWeek: schedule.day_of_week || '',
       startTime: schedule.start_time,
       endTime: schedule.end_time,
       programId: schedule.program.id.toString(),
+      scheduleType: schedule.schedule_type || 'weekly',
+      weekNumberInMonth: schedule.week_number_in_month?.toString() || '',
+      specificDate: schedule.specific_date || '',
     });
   };
 
   const handleCloseEditDialog = () => {
     setEditingSchedule(null);
-    setFormData({ dayOfWeek: '', startTime: '', endTime: '', programId: '' });
+    setFormData({ dayOfWeek: '', startTime: '', endTime: '', programId: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
   };
 
   const handleSubmit = async () => {
     if (!editingSchedule) return;
     try {
-      const updateData = {
-        dayOfWeek: formData.dayOfWeek,
+      const updateData: Record<string, unknown> = {
         startTime: formData.startTime,
         endTime: formData.endTime,
+        scheduleType: formData.scheduleType,
+        ...(formData.scheduleType !== 'monthly_dated' && { dayOfWeek: formData.dayOfWeek }),
+        ...(formData.scheduleType === 'monthly_weekday' && formData.weekNumberInMonth && { weekNumberInMonth: parseInt(formData.weekNumberInMonth, 10) }),
+        ...(formData.scheduleType === 'monthly_dated' && formData.specificDate && { specificDate: formData.specificDate }),
       };
       const response = await api.put<ScheduleType>(
         `/schedules/${editingSchedule.id}`,
@@ -216,7 +251,7 @@ export function SchedulesTable() {
 
   const handleOpenProgramDialog = (program: ProgramWithSchedules) => {
     setSelectedProgram(program);
-    setProgramFormData({ dayOfWeek: '', startTime: '', endTime: '' });
+    setProgramFormData({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
     setBulkSchedules([]);
     setSelectedDays([]);
     setBulkTimeRange({ startTime: '', endTime: '' });
@@ -254,7 +289,7 @@ export function SchedulesTable() {
   const handleCloseProgramDialog = () => {
     setOpenProgramDialog(false);
     setSelectedProgram(null);
-    setProgramFormData({ dayOfWeek: '', startTime: '', endTime: '' });
+    setProgramFormData({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
     setBulkSchedules([]);
     setSelectedDays([]);
     setBulkTimeRange({ startTime: '', endTime: '' });
@@ -264,18 +299,31 @@ export function SchedulesTable() {
   const handleAddProgramSchedule = async () => {
     if (!selectedProgram) return;
     try {
-      if (!programFormData.dayOfWeek || !programFormData.startTime || !programFormData.endTime) {
-        throw new Error('Todos los campos son requeridos');
+      const type = programFormData.scheduleType;
+      if (!programFormData.startTime || !programFormData.endTime) {
+        throw new Error('Los campos de horario son requeridos');
+      }
+      if ((type === 'weekly' || type === 'monthly_weekday') && !programFormData.dayOfWeek) {
+        throw new Error('El día de la semana es requerido');
+      }
+      if (type === 'monthly_weekday' && !programFormData.weekNumberInMonth) {
+        throw new Error('La semana del mes es requerida');
+      }
+      if (type === 'monthly_dated' && !programFormData.specificDate) {
+        throw new Error('La fecha específica es requerida');
       }
       if (!selectedProgram.channel_id) {
         throw new Error('El programa debe estar asociado a un canal');
       }
-      const newData = {
+      const newData: Record<string, unknown> = {
         programId: selectedProgram.id.toString(),
         channelId: selectedProgram.channel_id.toString(),
-        dayOfWeek: programFormData.dayOfWeek,
         startTime: programFormData.startTime,
         endTime: programFormData.endTime,
+        scheduleType: type,
+        ...(type !== 'monthly_dated' && { dayOfWeek: programFormData.dayOfWeek }),
+        ...(type === 'monthly_weekday' && { weekNumberInMonth: parseInt(programFormData.weekNumberInMonth, 10) }),
+        ...(type === 'monthly_dated' && { specificDate: programFormData.specificDate }),
       };
       const resp = await api.post<ScheduleType>('/schedules', newData, { headers: { Authorization: `Bearer ${typedSession?.accessToken}` } });
       const created = resp.data;
@@ -290,7 +338,7 @@ export function SchedulesTable() {
           : prev
       );
       setSuccess('Nuevo horario agregado correctamente');
-      setProgramFormData({ dayOfWeek: '', startTime: '', endTime: '' });
+      setProgramFormData({ dayOfWeek: '', startTime: '', endTime: '', scheduleType: 'weekly', weekNumberInMonth: '', specificDate: '' });
     } catch (err) {
       console.error('Error adding schedule:', err);
       setError((err as Error).message || 'Error al agregar el horario');
@@ -416,7 +464,7 @@ export function SchedulesTable() {
                     {program.schedules.map(schedule => (
                       <Chip
                         key={schedule.id}
-                        label={`${DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week} ${formatTime(schedule.start_time)}-${formatTime(schedule.end_time)}`}
+                        label={formatScheduleLabel(schedule)}
                         onClick={() => handleOpenEditDialog(schedule)}
                         onDelete={() => handleDelete(schedule.id)}
                       />
@@ -487,7 +535,8 @@ export function SchedulesTable() {
                     <Table size="small">
                       <TableHead>
                         <TableRow>
-                          <TableCell>Día</TableCell>
+                          <TableCell>Tipo</TableCell>
+                          <TableCell>Día / Fecha</TableCell>
                           <TableCell>Inicio</TableCell>
                           <TableCell>Fin</TableCell>
                           <TableCell>Acciones</TableCell>
@@ -501,16 +550,60 @@ export function SchedulesTable() {
                                 <TableCell>
                                   <TextField
                                     select
-                                    value={formData.dayOfWeek}
-                                    onChange={(e) => setFormData({ ...formData, dayOfWeek: e.target.value })}
+                                    value={formData.scheduleType}
+                                    onChange={(e) => setFormData({ ...formData, scheduleType: e.target.value })}
                                     fullWidth
+                                    size="small"
                                   >
-                                    {DAYS_OF_WEEK.map((day) => (
-                                      <MenuItem key={day.value} value={day.value}>
-                                        {day.label}
+                                    {SCHEDULE_TYPES.map((type) => (
+                                      <MenuItem key={type.value} value={type.value}>
+                                        {type.label}
                                       </MenuItem>
                                     ))}
                                   </TextField>
+                                </TableCell>
+                                <TableCell>
+                                  {formData.scheduleType === 'monthly_dated' ? (
+                                    <TextField
+                                      type="date"
+                                      value={formData.specificDate}
+                                      onChange={(e) => setFormData({ ...formData, specificDate: e.target.value })}
+                                      InputLabelProps={{ shrink: true }}
+                                      fullWidth
+                                      size="small"
+                                    />
+                                  ) : (
+                                    <Box sx={{ display: 'flex', gap: 1 }}>
+                                      {formData.scheduleType === 'monthly_weekday' && (
+                                        <TextField
+                                          select
+                                          value={formData.weekNumberInMonth}
+                                          onChange={(e) => setFormData({ ...formData, weekNumberInMonth: e.target.value })}
+                                          size="small"
+                                          sx={{ minWidth: 80 }}
+                                        >
+                                          {WEEK_NUMBERS.map((w) => (
+                                            <MenuItem key={w.value} value={w.value.toString()}>
+                                              {w.label}
+                                            </MenuItem>
+                                          ))}
+                                        </TextField>
+                                      )}
+                                      <TextField
+                                        select
+                                        value={formData.dayOfWeek}
+                                        onChange={(e) => setFormData({ ...formData, dayOfWeek: e.target.value })}
+                                        fullWidth
+                                        size="small"
+                                      >
+                                        {DAYS_OF_WEEK.map((day) => (
+                                          <MenuItem key={day.value} value={day.value}>
+                                            {day.label}
+                                          </MenuItem>
+                                        ))}
+                                      </TextField>
+                                    </Box>
+                                  )}
                                 </TableCell>
                                 <TableCell>
                                   <TextField
@@ -519,6 +612,7 @@ export function SchedulesTable() {
                                     onChange={(e) => setFormData({ ...formData, startTime: e.target.value })}
                                     InputLabelProps={{ shrink: true }}
                                     fullWidth
+                                    size="small"
                                   />
                                 </TableCell>
                                 <TableCell>
@@ -528,6 +622,7 @@ export function SchedulesTable() {
                                     onChange={(e) => setFormData({ ...formData, endTime: e.target.value })}
                                     InputLabelProps={{ shrink: true }}
                                     fullWidth
+                                    size="small"
                                   />
                                 </TableCell>
                                 <TableCell>
@@ -541,7 +636,21 @@ export function SchedulesTable() {
                               </>
                             ) : (
                               <>
-                                <TableCell>{DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week}</TableCell>
+                                <TableCell>
+                                  <Chip
+                                    label={SCHEDULE_TYPES.find(t => t.value === (schedule.schedule_type || 'weekly'))?.label || 'Semanal'}
+                                    size="small"
+                                    color={schedule.schedule_type === 'monthly_weekday' ? 'primary' : schedule.schedule_type === 'monthly_dated' ? 'secondary' : 'default'}
+                                  />
+                                </TableCell>
+                                <TableCell>
+                                  {schedule.schedule_type === 'monthly_dated'
+                                    ? schedule.specific_date || '-'
+                                    : schedule.schedule_type === 'monthly_weekday'
+                                      ? `${WEEK_NUMBERS.find(w => w.value === schedule.week_number_in_month)?.label || ''} ${DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week || ''}`
+                                      : DAYS_OF_WEEK.find(d => d.value === schedule.day_of_week)?.label || schedule.day_of_week || '-'
+                                  }
+                                </TableCell>
                                 <TableCell>{formatTime(schedule.start_time)}</TableCell>
                                 <TableCell>{formatTime(schedule.end_time)}</TableCell>
                                 <TableCell>
@@ -564,43 +673,109 @@ export function SchedulesTable() {
                   <Typography variant="h6" color="text.primary" sx={{ mb: 2 }}>
                     Agregar Nuevo Horario
                   </Typography>
-                  <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 2 }}>
                     <TextField
                       select
-                      label="Día de la semana"
-                      value={programFormData.dayOfWeek}
-                      onChange={(e) => setProgramFormData({ ...programFormData, dayOfWeek: e.target.value })}
+                      label="Tipo de recurrencia"
+                      value={programFormData.scheduleType}
+                      onChange={(e) => setProgramFormData({ ...programFormData, scheduleType: e.target.value, dayOfWeek: '', weekNumberInMonth: '', specificDate: '' })}
                       fullWidth
                     >
-                      {DAYS_OF_WEEK.map((day) => (
-                        <MenuItem key={day.value} value={day.value}>
-                          {day.label}
+                      {SCHEDULE_TYPES.map((type) => (
+                        <MenuItem key={type.value} value={type.value}>
+                          {type.label}
                         </MenuItem>
                       ))}
                     </TextField>
-                    <TextField
-                      label="Hora de inicio"
-                      type="time"
-                      value={programFormData.startTime}
-                      onChange={(e) => setProgramFormData({ ...programFormData, startTime: e.target.value })}
-                      InputLabelProps={{ shrink: true }}
-                      fullWidth
-                    />
-                    <TextField
-                      label="Hora de fin"
-                      type="time"
-                      value={programFormData.endTime}
-                      onChange={(e) => setProgramFormData({ ...programFormData, endTime: e.target.value })}
-                      InputLabelProps={{ shrink: true }}
-                      fullWidth
-                    />
-                    <Button
-                      variant="contained"
-                      onClick={handleAddProgramSchedule}
-                      sx={{ alignSelf: 'flex-end' }}
-                    >
-                      Agregar
-                    </Button>
+
+                    {programFormData.scheduleType === 'weekly' && (
+                      <TextField
+                        select
+                        label="Día de la semana"
+                        value={programFormData.dayOfWeek}
+                        onChange={(e) => setProgramFormData({ ...programFormData, dayOfWeek: e.target.value })}
+                        fullWidth
+                      >
+                        {DAYS_OF_WEEK.map((day) => (
+                          <MenuItem key={day.value} value={day.value}>
+                            {day.label}
+                          </MenuItem>
+                        ))}
+                      </TextField>
+                    )}
+
+                    {programFormData.scheduleType === 'monthly_weekday' && (
+                      <Box sx={{ display: 'flex', gap: 2 }}>
+                        <TextField
+                          select
+                          label="Semana del mes"
+                          value={programFormData.weekNumberInMonth}
+                          onChange={(e) => setProgramFormData({ ...programFormData, weekNumberInMonth: e.target.value })}
+                          fullWidth
+                        >
+                          {WEEK_NUMBERS.map((w) => (
+                            <MenuItem key={w.value} value={w.value.toString()}>
+                              {w.label}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                        <TextField
+                          select
+                          label="Día de la semana"
+                          value={programFormData.dayOfWeek}
+                          onChange={(e) => setProgramFormData({ ...programFormData, dayOfWeek: e.target.value })}
+                          fullWidth
+                        >
+                          {DAYS_OF_WEEK.map((day) => (
+                            <MenuItem key={day.value} value={day.value}>
+                              {day.label}
+                            </MenuItem>
+                          ))}
+                        </TextField>
+                      </Box>
+                    )}
+
+                    {programFormData.scheduleType === 'monthly_dated' && (
+                      <Box>
+                        <TextField
+                          label="Fecha específica"
+                          type="date"
+                          value={programFormData.specificDate}
+                          onChange={(e) => setProgramFormData({ ...programFormData, specificDate: e.target.value })}
+                          InputLabelProps={{ shrink: true }}
+                          fullWidth
+                        />
+                        <Alert severity="info" icon={<InfoOutlinedIcon />} sx={{ mt: 1 }}>
+                          Deberás cargar manualmente cada fecha cuando se confirme.
+                        </Alert>
+                      </Box>
+                    )}
+
+                    <Box sx={{ display: 'flex', gap: 2 }}>
+                      <TextField
+                        label="Hora de inicio"
+                        type="time"
+                        value={programFormData.startTime}
+                        onChange={(e) => setProgramFormData({ ...programFormData, startTime: e.target.value })}
+                        InputLabelProps={{ shrink: true }}
+                        fullWidth
+                      />
+                      <TextField
+                        label="Hora de fin"
+                        type="time"
+                        value={programFormData.endTime}
+                        onChange={(e) => setProgramFormData({ ...programFormData, endTime: e.target.value })}
+                        InputLabelProps={{ shrink: true }}
+                        fullWidth
+                      />
+                      <Button
+                        variant="contained"
+                        onClick={handleAddProgramSchedule}
+                        sx={{ alignSelf: 'flex-end' }}
+                      >
+                        Agregar
+                      </Button>
+                    </Box>
                   </Box>
                 </Box>
               )}

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -6,6 +6,9 @@ export interface Schedule {
   start_time: string;
   end_time: string;
   subscribed: boolean;
+  schedule_type?: 'weekly' | 'monthly_weekday' | 'monthly_dated';
+  week_number_in_month?: number | null;
+  specific_date?: string | null;
   program: {
     id: number;
     name: string;


### PR DESCRIPTION
## Summary

- `SchedulesTable`: "Tipo de recurrencia" selector (Semanal / Mensual fijo / Mensual por fecha) with conditional fields for each mode
- `ProgramSchedulesSection`: same recurrence modes available in the "Editar Programa" dialog
- TypeScript `Schedule` type updated: `schedule_type`, `week_number_in_month`, `specific_date` fields added
- Fix: "Agregar Horario" button no longer overflows the dialog (moved to its own full-width row)

## Test plan

- [ ] Gestión de Horarios: create a Semanal schedule — existing flow unchanged
- [ ] Gestión de Horarios: create a Mensual fijo schedule (e.g. 1° Jueves) — verify it saves and shows the correct badge and label
- [ ] Gestión de Horarios: create a Mensual por fecha schedule — verify date picker appears and informational alert is shown
- [ ] Editar Programa dialog: verify all three recurrence types are available when adding/editing schedules
- [ ] Refresh the backoffice after creating a monthly schedule — verify it still appears (raw=true fix)
- [ ] Verify "Agregar Horario" button renders correctly without overflow on all schedule types

🤖 Generated with [Claude Code](https://claude.com/claude-code)