### PR TITLE
🎨 Palette: Add tooltips to password visibility toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-05-27 - Tooltips for Icon-only states
+**Learning:** Adding dynamic Tooltips to icon-only toggles (like eye/eye-off for password visibility) improves accessibility for sighted users who might not immediately intuit the icon meaning, complementing the ARIA labels used for screen readers. Using the `arrow` prop in MUI adds polish.
+**Action:** When creating or updating functional icon toggles, wrap the IconButton in a `<Tooltip>` with a title matching the ARIA label's dynamic text.

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -8,7 +8,8 @@ import {
   InputAdornment,
   IconButton,
   Typography,
-  CircularProgress
+  CircularProgress,
+  Tooltip
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -94,14 +95,16 @@ export default function ExistingUserStep({
           ),
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton
-                aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                onClick={() => setShow(s => !s)}
-                edge="end"
-                size="small"
-              >
-                {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-              </IconButton>
+              <Tooltip title={show ? 'Ocultar contraseña' : 'Mostrar contraseña'} arrow>
+                <IconButton
+                  aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  onClick={() => setShow(s => !s)}
+                  edge="end"
+                  size="small"
+                >
+                  {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
             </InputAdornment>
           )
         }}

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -9,7 +9,8 @@ import {
   IconButton,
   LinearProgress,
   Typography,
-  CircularProgress
+  CircularProgress,
+  Tooltip
 } from '@mui/material';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -87,13 +88,15 @@ export default function PasswordStep({
           ),
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton
-                aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                size="small"
-                onClick={() => setShow(s => !s)}
-              >
-                {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-              </IconButton>
+              <Tooltip title={show ? 'Ocultar contraseña' : 'Mostrar contraseña'} arrow>
+                <IconButton
+                  aria-label={show ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  size="small"
+                  onClick={() => setShow(s => !s)}
+                >
+                  {show ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
             </InputAdornment>
           )
         }}
@@ -119,13 +122,15 @@ export default function PasswordStep({
           ),
           endAdornment: (
             <InputAdornment position="end">
-              <IconButton
-                aria-label={show2 ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                size="small"
-                onClick={() => setShow2(s => !s)}
-              >
-                {show2 ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-              </IconButton>
+              <Tooltip title={show2 ? 'Ocultar contraseña' : 'Mostrar contraseña'} arrow>
+                <IconButton
+                  aria-label={show2 ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                  size="small"
+                  onClick={() => setShow2(s => !s)}
+                >
+                  {show2 ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
             </InputAdornment>
           )
         }}


### PR DESCRIPTION
💡 **What**: Added MUI `<Tooltip>` wrappers to the password visibility toggle `IconButton` components in `PasswordStep` and `ExistingUserStep`.
🎯 **Why**: Sighted users benefit from explicit text labels describing icon-only state toggles. The eye/eye-off icon is common but a tooltip clarifies exactly what action will occur ("Mostrar contraseña" or "Ocultar contraseña").
📸 **Before/After**: Visually, the UI looks identical until a user hovers over the eye icon in the password field, which now displays a standard MUI tooltip arrow with descriptive text matching the state.
♿ **Accessibility**: Complements the existing `aria-label` screen-reader support with visual context for sighted keyboard/mouse users without breaking focus order.

---
*PR created automatically by Jules for task [11703196937308830592](https://jules.google.com/task/11703196937308830592) started by @matiasrozenblum*