### PR TITLE
enhancement: add robots.txt and sitemap.xml for SEO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.18.2] - 2026-05-26
+
+### Added
+- `robots.txt`: disallow indexing of `/backoffice/`, `/api/`, `/profile` and `/subscriptions`
+- `sitemap.xml`: homepage (hourly), streamers (daily), legal pages (monthly)
+
+---
+
 ## [1.18.1] - 2026-05-25
 
 ### Added

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/backoffice/', '/api/', '/profile', '/subscriptions'],
+      },
+    ],
+    sitemap: 'https://laguiadelstreaming.com/sitemap.xml',
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://laguiadelstreaming.com',
+      changeFrequency: 'hourly',
+      priority: 1,
+    },
+    {
+      url: 'https://laguiadelstreaming.com/streamers',
+      changeFrequency: 'daily',
+      priority: 0.7,
+    },
+    {
+      url: 'https://laguiadelstreaming.com/legal/politica-de-privacidad',
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
+    {
+      url: 'https://laguiadelstreaming.com/terminos-y-condiciones',
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- `robots.ts`: disallow crawling of `/backoffice/`, `/api/`, `/profile`, `/subscriptions`
- `sitemap.ts`: homepage (hourly), streamers (daily), legal pages (monthly)
- Both served automatically by Next.js at `/robots.txt` and `/sitemap.xml`

## Test plan
- [ ] Verify `/robots.txt` renders correctly in staging
- [ ] Verify `/sitemap.xml` renders correctly in staging
- [ ] Confirm backoffice is disallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)