### PR TITLE
🎨 Palette: Add tooltips to backoffice table action icons

### DIFF
--- a/src/components/backoffice/PanelistsTable.tsx
+++ b/src/components/backoffice/PanelistsTable.tsx
@@ -21,6 +21,7 @@ import {
   Chip,
   Autocomplete,
   useTheme,
+  Tooltip,
 } from '@mui/material';
 import { Edit, Delete, Add, Group } from '@mui/icons-material';
 import { Panelist } from '@/types/panelist';
@@ -273,15 +274,21 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
                   </Box>
                 </TableCell>
                 <TableCell>
-                  <IconButton aria-label="Editar panelista" onClick={() => handleOpenDialog(panelist)}>
-                    <Edit />
-                  </IconButton>
-                  <IconButton aria-label="Gestionar programas" onClick={() => handleOpenProgramsDialog(panelist)}>
-                    <Group />
-                  </IconButton>
-                  <IconButton aria-label="Eliminar panelista" onClick={() => handleDelete(String(panelist.id))}>
-                    <Delete />
-                  </IconButton>
+                  <Tooltip title="Editar panelista">
+                    <IconButton aria-label="Editar panelista" onClick={() => handleOpenDialog(panelist)}>
+                      <Edit />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Gestionar programas">
+                    <IconButton aria-label="Gestionar programas" onClick={() => handleOpenProgramsDialog(panelist)}>
+                      <Group />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Eliminar panelista">
+                    <IconButton aria-label="Eliminar panelista" onClick={() => handleDelete(String(panelist.id))}>
+                      <Delete />
+                    </IconButton>
+                  </Tooltip>
                 </TableCell>
               </TableRow>
             ))}

--- a/src/components/backoffice/ProposedChangesTable.tsx
+++ b/src/components/backoffice/ProposedChangesTable.tsx
@@ -15,6 +15,7 @@ import {
   Alert,
   Typography,
   CircularProgress,
+  Tooltip,
 } from '@mui/material';
 import { Check, Close } from '@mui/icons-material';
 import { api } from '@/services/api';
@@ -227,20 +228,24 @@ export default function ProposedChangesTable() {
                     )}
                   </TableCell>
                   <TableCell>
-                    <IconButton
-                      aria-label="Aprobar"
-                      onClick={() => handleAction(change.id, 'approve')}
-                      color="success"
-                    >
-                      <Check />
-                    </IconButton>
-                    <IconButton
-                      aria-label="Rechazar"
-                      onClick={() => handleAction(change.id, 'reject')}
-                      color="error"
-                    >
-                      <Close />
-                    </IconButton>
+                    <Tooltip title="Aprobar">
+                      <IconButton
+                        aria-label="Aprobar"
+                        onClick={() => handleAction(change.id, 'approve')}
+                        color="success"
+                      >
+                        <Check />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Rechazar">
+                      <IconButton
+                        aria-label="Rechazar"
+                        onClick={() => handleAction(change.id, 'reject')}
+                        color="error"
+                      >
+                        <Close />
+                      </IconButton>
+                    </Tooltip>
                   </TableCell>
                 </TableRow>
               ))

--- a/src/components/backoffice/UsersTable.tsx
+++ b/src/components/backoffice/UsersTable.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   Pagination,
   SelectChangeEvent,
+  Tooltip,
 } from '@mui/material';
 import { Edit, Delete, Add, NavigateBefore, NavigateNext } from '@mui/icons-material';
 import { User } from '@/types/user';
@@ -357,25 +358,33 @@ export function UsersTable() {
           
           {/* Page Navigation */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <IconButton
-              aria-label="Página anterior"
-              onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage - 1)}
-              disabled={currentPage <= 1}
-              size="small"
-            >
-              <NavigateBefore />
-            </IconButton>
+            <Tooltip title="Página anterior">
+              <span>
+                <IconButton
+                  aria-label="Página anterior"
+                  onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage - 1)}
+                  disabled={currentPage <= 1}
+                  size="small"
+                >
+                  <NavigateBefore />
+                </IconButton>
+              </span>
+            </Tooltip>
             <Typography variant="body2" color="text.primary">
               Página {currentPage} de {totalPages}
             </Typography>
-            <IconButton
-              aria-label="Página siguiente"
-              onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage + 1)}
-              disabled={currentPage >= totalPages}
-              size="small"
-            >
-              <NavigateNext />
-            </IconButton>
+            <Tooltip title="Página siguiente">
+              <span>
+                <IconButton
+                  aria-label="Página siguiente"
+                  onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage + 1)}
+                  disabled={currentPage >= totalPages}
+                  size="small"
+                >
+                  <NavigateNext />
+                </IconButton>
+              </span>
+            </Tooltip>
           </Box>
           
           <Button variant="contained" startIcon={<Add />} onClick={() => handleOpenDialog()}>
@@ -426,12 +435,16 @@ export function UsersTable() {
                 </TableCell>
                 <TableCell>
                   <Box sx={{ display: 'flex', gap: 0.5 }}>
-                    <IconButton aria-label="Editar usuario" size="small" onClick={() => handleOpenDialog(user)}>
-                      <Edit />
-                    </IconButton>
-                    <IconButton aria-label="Eliminar usuario" size="small" onClick={() => handleDelete(user.id)}>
-                      <Delete />
-                    </IconButton>
+                    <Tooltip title="Editar usuario">
+                      <IconButton aria-label="Editar usuario" size="small" onClick={() => handleOpenDialog(user)}>
+                        <Edit />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar usuario">
+                      <IconButton aria-label="Eliminar usuario" size="small" onClick={() => handleDelete(user.id)}>
+                        <Delete />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
💡 **What**: Added `Tooltip`s to multiple icon-only buttons in backoffice data tables (`ProposedChangesTable`, `UsersTable`, `PanelistsTable`). For the pagination arrow buttons which can be disabled, they were wrapped in `<span>` tags.

🎯 **Why**: While the buttons already had `aria-label`s for screen readers, sighted users hovering over the standalone icons (like Edit, Delete, Groups, Approve, Reject, Next/Prev) received no textual feedback on the button's exact function. Adding tooltips makes the interface significantly more intuitive.

♿ **Accessibility**: 
- Tooltips added using native Material UI `<Tooltip>` components. 
- Properly accommodated disabled buttons by wrapping them in `<span>`s, guaranteeing tooltips remain functional when buttons are inactive.

**Before/After**: Sighted users will now see floating tooltips in Spanish when interacting with these data tables.

---
*PR created automatically by Jules for task [13341910137877879265](https://jules.google.com/task/13341910137877879265) started by @matiasrozenblum*