### PR TITLE
🎨 Palette: Add loading indicator and ARIA label to ProfileCompletionForm submit button

### DIFF
--- a/src/components/ProfileCompletionForm.tsx
+++ b/src/components/ProfileCompletionForm.tsx
@@ -19,6 +19,7 @@ import {
   IconButton,
   Snackbar,
   Alert as MuiAlert,
+  CircularProgress,
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -337,8 +338,9 @@ export default function ProfileCompletionForm({ registrationToken, initialUser }
                   variant="contained"
                   size="small"
                   disabled={isLoading}
+                  aria-label={isLoading ? 'Guardando' : undefined}
                 >
-                  {isLoading ? 'Guardando...' : 'Guardar'}
+                  {isLoading ? <CircularProgress size={24} color="inherit" /> : 'Guardar'}
                 </Button>
               </Box>
             </Box>


### PR DESCRIPTION
💡 **What:** Added a `<CircularProgress>` spinner to the submit button in `ProfileCompletionForm.tsx` replacing the static "Guardando..." text when `isLoading` is true. Included dynamic `aria-label` to announce the loading state.

🎯 **Why:** To provide clear, animated visual feedback to users during an asynchronous profile save, making the UI feel more responsive, and ensuring screen readers are informed of the loading state.

♿ **Accessibility:** Added an `aria-label` that switches to "Guardando" when `isLoading` is true, ensuring screen readers receive appropriate feedback despite the visual-only spinner.

---
*PR created automatically by Jules for task [10744401132891403873](https://jules.google.com/task/10744401132891403873) started by @matiasrozenblum*