### PR TITLE
Release 1.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.18.3] - 2026-05-30
+
+### Fixed
+- Banner create/update/delete no longer invalidates the full Next.js Data Cache for the home page. The banners fetch now uses cache tag `banners`, and `/api/revalidate` supports tag-based revalidation. Previously, any banner change triggered `revalidatePath('/')` which busted all server-side caches (including the heavy week-schedules endpoint), causing a Vercel 15-second timeout loop that could take 15–20 minutes to recover from.
+
+---
+
 ## [1.18.2] - 2026-05-26
 
 ### Added

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,31 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 export async function POST(req: NextRequest) {
-  console.log(`[Frontend Revalidate] ===== REVALIDATION REQUEST RECEIVED =====`);
-  console.log(`[Frontend Revalidate] Request URL: ${req.url}`);
-  console.log(`[Frontend Revalidate] Request headers:`, Object.fromEntries(req.headers.entries()));
-  
-  const { path, secret } = await req.json();
-  
-  console.log(`[Frontend Revalidate] Received revalidation request for path: ${path}`);
-  console.log(`[Frontend Revalidate] Secret provided: ${secret ? secret.substring(0, 8) + '...' : 'none'}`);
-  console.log(`[Frontend Revalidate] Expected secret: ${process.env.REVALIDATE_SECRET ? process.env.REVALIDATE_SECRET.substring(0, 8) + '...' : 'none'}`);
+  const { path, tag, secret } = await req.json();
 
-  // Protect with a secret token
   if (secret !== process.env.REVALIDATE_SECRET) {
-    console.log(`[Frontend Revalidate] ❌ Invalid secret provided`);
+    console.log(`[Revalidate] ❌ Invalid secret`);
     return NextResponse.json({ message: 'Invalid secret' }, { status: 401 });
   }
 
   try {
-    console.log(`[Frontend Revalidate] ✅ Valid secret, revalidating path: ${path}`);
-    // Revalidate the given path
-    await revalidatePath(path);
-    console.log(`[Frontend Revalidate] ✅ Successfully revalidated path: ${path}`);
-    return NextResponse.json({ revalidated: true, now: Date.now(), path });
+    if (tag) {
+      revalidateTag(tag);
+      console.log(`[Revalidate] ✅ Revalidated tag: ${tag}`);
+      return NextResponse.json({ revalidated: true, now: Date.now(), tag });
+    }
+    if (path) {
+      revalidatePath(path);
+      console.log(`[Revalidate] ✅ Revalidated path: ${path}`);
+      return NextResponse.json({ revalidated: true, now: Date.now(), path });
+    }
+    return NextResponse.json({ message: 'Either path or tag is required' }, { status: 400 });
   } catch (err) {
-    console.log(`[Frontend Revalidate] ❌ Error revalidating path ${path}:`, err);
+    console.log(`[Revalidate] ❌ Error:`, err);
     return NextResponse.json({ message: 'Error revalidating', error: err }, { status: 500 });
   }
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,7 +61,7 @@ async function getInitialData(): Promise<InitialData> {
     const bannersPromise = fetch(
       `${process.env.NEXT_PUBLIC_API_URL}/banners/active`,
       {
-        next: { revalidate: 300 } // Cache for 5 minutes, same as API route
+        next: { revalidate: 300, tags: ['banners'] }
       }
     ).then(res => res.ok ? res.json() : []).catch(() => []);
 


### PR DESCRIPTION
## [1.18.3] - 2026-05-30

### Fixed
- Banner create/update/delete no longer invalidates the full Next.js Data Cache for the home page. The banners fetch now uses cache tag `banners`, and `/api/revalidate` supports tag-based revalidation. Previously, any banner change triggered `revalidatePath('/')` which busted all server-side caches (including the heavy week-schedules endpoint), causing a Vercel 15-second timeout loop that could take 15–20 minutes to recover from.

## Changes
- `src/app/page.tsx`: banners fetch uses `next: { revalidate: 300, tags: ['banners'] }`
- `src/app/api/revalidate/route.ts`: supports tag-based revalidation via `revalidateTag(tag)`

## Deploy note
Deploy frontend first, then the companion backend release (`fix/banner-revalidation-tags` on `streaming-guide-backend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)