### PR TITLE
🎨 Palette: Add dynamic ARIA labels to Subscriptions Accordion toggles

### DIFF
--- a/src/components/SubscriptionsClient.tsx
+++ b/src/components/SubscriptionsClient.tsx
@@ -476,7 +476,7 @@ export default function SubscriptionsClient({ initialSubscriptions, initialStrea
                     <Typography variant="h6" component="h2" fontWeight={600} sx={{ color: headerTextColor, textTransform: 'uppercase', fontSize: '0.85rem', letterSpacing: '0.05em' }}>
                       Programas
                     </Typography>
-                    <IconButton aria-label="Expandir o contraer programas" size="small" disableRipple sx={{ color: headerTextColor }}>
+                    <IconButton aria-label={isProgramsExpanded ? "Contraer programas" : "Expandir programas"} size="small" disableRipple sx={{ color: headerTextColor }}>
                       <Box
                         component="svg"
                         width="16"
@@ -552,7 +552,7 @@ export default function SubscriptionsClient({ initialSubscriptions, initialStrea
                     <Typography variant="h6" component="h2" fontWeight={600} sx={{ color: headerTextColor, textTransform: 'uppercase', fontSize: '0.85rem', letterSpacing: '0.05em' }}>
                       Streamers
                     </Typography>
-                    <IconButton aria-label="Expandir o contraer streamers" size="small" disableRipple sx={{ color: headerTextColor }}>
+                    <IconButton aria-label={isStreamersExpanded ? "Contraer streamers" : "Expandir streamers"} size="small" disableRipple sx={{ color: headerTextColor }}>
                       <Box
                         component="svg"
                         width="16"


### PR DESCRIPTION
💡 **What:** Replaced static ARIA labels on the "Programas" and "Streamers" accordion toggles in the Subscriptions page with dynamic ones that reflect the expanded/collapsed state.
🎯 **Why:** To improve accessibility for screen reader users by providing precise feedback on the current action the button will perform (e.g., "Contraer programas" vs "Expandir programas" instead of the ambiguous "Expandir o contraer programas").
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce the exact action the toggle button will perform, improving navigation clarity.

---
*PR created automatically by Jules for task [5040968129729727171](https://jules.google.com/task/5040968129729727171) started by @matiasrozenblum*