### PR TITLE
🎨 Palette: [UX improvement] Add tooltip to footer email button

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React from 'react';
-import { Box, Typography, IconButton, Button } from '@mui/material';
+import { Box, Typography, IconButton, Button, Tooltip } from '@mui/material';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import { useCookieConsent } from '@/contexts/CookieConsentContext';
 
@@ -93,22 +93,24 @@ const Footer: React.FC = () => {
       </Typography>
 
       {/* Botón de mail SOLO en web (sm+) */}
-      <IconButton
-        component="a"
-        href={`mailto:${email}`}
-        aria-label="Enviar correo"
-        sx={{
-          display: { xs: 'none', sm: 'inline-flex' }, // <-- oculto en mobile
-          position: 'absolute',
-          top: '50%',
-          right: 8,
-          transform: 'translateY(-50%)',
-          color: 'text.secondary',
-          '&:hover': { color: 'primary.main' },
-        }}
-      >
-        <MailOutlineIcon />
-      </IconButton>
+      <Tooltip title="Enviar correo" arrow>
+        <IconButton
+          component="a"
+          href={`mailto:${email}`}
+          aria-label="Enviar correo"
+          sx={{
+            display: { xs: 'none', sm: 'inline-flex' }, // <-- oculto en mobile
+            position: 'absolute',
+            top: '50%',
+            right: 8,
+            transform: 'translateY(-50%)',
+            color: 'text.secondary',
+            '&:hover': { color: 'primary.main' },
+          }}
+        >
+          <MailOutlineIcon />
+        </IconButton>
+      </Tooltip>
     </Box>
   );
 };


### PR DESCRIPTION
**💡 What:** Added a MUI `<Tooltip>` around the email `<IconButton>` in the Footer.
**🎯 Why:** While screen readers announce "Enviar correo" via `aria-label`, sighted users navigating via mouse/keyboard focus had no context for the icon's action unless they clicked it or guessed. This improves UX by making the interface more intuitive and following the project's accessibility guidelines for icon-only components.
**♿ Accessibility:** Enhanced visual context for keyboard navigation focus and mouse hover without breaking the existing semantic `aria-label`.

---
*PR created automatically by Jules for task [2283422146400013450](https://jules.google.com/task/2283422146400013450) started by @matiasrozenblum*