### PR TITLE
🎨 Palette: Add tooltip to LoginModal close button

### DIFF
--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   Dialog, DialogTitle, DialogContent,
-  IconButton, Box, useTheme, Stepper, Step, StepLabel, StepConnector, stepConnectorClasses, StepIconProps, Button
+  IconButton, Box, useTheme, Stepper, Step, StepLabel, StepConnector, stepConnectorClasses, StepIconProps, Button, Tooltip
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
@@ -280,7 +280,9 @@ export default function LoginModal({ open, onClose }: { open: boolean; onClose: 
                     ? (forgotPassword ? 'Nueva contraseña' : 'Creá tu contraseña')
                     : ''
         )}
-        <IconButton aria-label="Cerrar modal" onClick={socialLoginPending ? undefined : onClose}><CloseIcon /></IconButton>
+        <Tooltip title="Cerrar modal">
+          <IconButton aria-label="Cerrar modal" onClick={socialLoginPending ? undefined : onClose}><CloseIcon /></IconButton>
+        </Tooltip>
       </DialogTitle>
 
       {(


### PR DESCRIPTION
💡 **What**: Added a Tooltip to the close button in the Login Modal.
🎯 **Why**: While the button had an `aria-label` for screen readers, it lacked visual context on hover for sighted users. Adding a Tooltip improves usability by explicitly stating the button's action.
♿ **Accessibility**: Improves accessibility and general UX for sighted users by providing a clear text description on hover.

---
*PR created automatically by Jules for task [14525253441664645906](https://jules.google.com/task/14525253441664645906) started by @matiasrozenblum*