### PR TITLE
fix: ghost blocks when switching days (v1.19.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.19.2] - 2026-06-06
+
+### Fixed
+- Bloques fantasma al cambiar de día: se corrige la key de `React.Fragment` en `ScheduleRow` usando `scheduleId|programId` en lugar de solo `programId`. El mismo programa puede aparecer dos veces en la lista de un día (como bloque regular y como overflow inyectado del día siguiente), lo que causaba colisión de keys y que React dejara bloques del día anterior visibles al navegar entre días
+
+---
+
 ## [1.19.1] - 2026-06-03
 
 ### Added

--- a/src/components/ScheduleRow.tsx
+++ b/src/components/ScheduleRow.tsx
@@ -341,7 +341,7 @@ export const ScheduleRow = ({
             const hasTimeOverlap = laneIndex !== undefined;
 
             return (
-              <React.Fragment key={p.id}>
+              <React.Fragment key={`${p.scheduleId}|${p.id}`}>
                 <ProgramBlock
                   id={p.id}
                   name={p.name}


### PR DESCRIPTION
## Summary
- Corrige bloques fantasma al cambiar de día en la grilla: bloques del día anterior quedaban visibles superpuestos sobre los del nuevo día

## Root cause
`ScheduleRow` usaba `key={p.id}` (program ID) en cada `React.Fragment`. Con el feature de overflow, el mismo programa puede aparecer dos veces en la lista de un día: una vez como bloque regular y otra inyectado como overflow desde el día siguiente. React no podía distinguirlos por key, corrompía el DOM y no desmontaba correctamente los bloques al cambiar de día.

## Fix
`key={p.id}` → `key={\`${p.scheduleId}|${p.id}\`}`. El `scheduleId` es único por entrada de schedule en la DB, garantizando que no haya colisiones ni entre el mismo programa en distintos días ni entre bloque regular y overflow del mismo programa.

## Test plan
- [ ] Cambiar entre días y verificar que no quedan bloques fantasma de días anteriores
- [ ] Verificar que los bloques de overflow siguen funcionando correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)