### PR TITLE
Release 1.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.19.2] - 2026-06-06
+
+### Fixed
+- Bloques fantasma al cambiar de día: se corrige la key de `React.Fragment` en `ScheduleRow` usando `scheduleId|programId` en lugar de solo `programId`. El mismo programa puede aparecer dos veces en la lista de un día (como bloque regular y como overflow inyectado del día siguiente), lo que causaba colisión de keys y que React dejara bloques del día anterior visibles al navegar entre días
+
+---
+
 ## [1.19.1] - 2026-06-03
 
 ### Added

--- a/src/components/ScheduleRow.tsx
+++ b/src/components/ScheduleRow.tsx
@@ -341,7 +341,7 @@ export const ScheduleRow = ({
             const hasTimeOverlap = laneIndex !== undefined;
 
             return (
-              <React.Fragment key={p.id}>
+              <React.Fragment key={`${p.scheduleId}|${p.id}`}>
                 <ProgramBlock
                   id={p.id}
                   name={p.name}


### PR DESCRIPTION
## [1.19.2] - 2026-06-06

### Fixed
- Bloques fantasma al cambiar de día: se corrige la key de `React.Fragment` en `ScheduleRow` usando `scheduleId|programId` en lugar de solo `programId`. El mismo programa puede aparecer dos veces en la lista de un día (como bloque regular y como overflow inyectado del día siguiente), lo que causaba colisión de keys y que React dejara bloques del día anterior visibles al navegar entre días

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)