### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons in ProfileClient

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2025-02-19 - Missing Tooltips on Icon-Only Buttons
+**Learning:** Sighted users can struggle to understand the purpose of icon-only buttons (like the edit pencil or show/hide password eyes) if there is no visible label, even when `aria-label` is present for screen readers.
+**Action:** Always wrap `IconButton` components in Material-UI with a `<Tooltip>` component to provide a visible hover label. Use the `title` prop on the `Tooltip` to mirror the `aria-label`.

--- a/src/components/ProfileClient.tsx
+++ b/src/components/ProfileClient.tsx
@@ -24,6 +24,7 @@ import {
   MenuItem,
   Collapse,
   Snackbar,
+  Tooltip,
 } from '@mui/material';
 import VpnKeyIcon from '@mui/icons-material/VpnKey';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
@@ -82,17 +83,19 @@ const ProfileSection = ({ title, value, onEdit }: { title: string; value: React.
   >
     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1.5 }}>
       <Typography variant="h6" sx={{ fontSize: '1.1rem', fontWeight: 600 }}>{title}</Typography>
-      <IconButton
-        aria-label="Editar información"
-        onClick={onEdit}
-        size="small"
-        sx={{
-          color: 'primary.main',
-          '&:hover': { backgroundColor: 'primary.main', color: 'primary.contrastText' }
-        }}
-      >
-        <EditIcon fontSize="small" />
-      </IconButton>
+      <Tooltip title="Editar información" arrow>
+        <IconButton
+          aria-label="Editar información"
+          onClick={onEdit}
+          size="small"
+          sx={{
+            color: 'primary.main',
+            '&:hover': { backgroundColor: 'primary.main', color: 'primary.contrastText' }
+          }}
+        >
+          <EditIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
     </Box>
     {value}
   </Paper>
@@ -873,13 +876,15 @@ export default function ProfileClient({ initialUser }: ProfileClientProps) {
                   ),
                   endAdornment: (
                     <InputAdornment position="end">
-                      <IconButton
-                        aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                        size="small"
-                        onClick={() => setShowPassword(s => !s)}
-                      >
-                        {showPassword ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-                      </IconButton>
+                      <Tooltip title={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'} arrow>
+                        <IconButton
+                          aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                          size="small"
+                          onClick={() => setShowPassword(s => !s)}
+                        >
+                          {showPassword ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
                     </InputAdornment>
                   )
                 }}
@@ -913,13 +918,15 @@ export default function ProfileClient({ initialUser }: ProfileClientProps) {
                   ),
                   endAdornment: (
                     <InputAdornment position="end">
-                      <IconButton
-                        aria-label={showConfirmPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
-                        size="small"
-                        onClick={() => setShowConfirmPassword(s => !s)}
-                      >
-                        {showConfirmPassword ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
-                      </IconButton>
+                      <Tooltip title={showConfirmPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'} arrow>
+                        <IconButton
+                          aria-label={showConfirmPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                          size="small"
+                          onClick={() => setShowConfirmPassword(s => !s)}
+                        >
+                          {showConfirmPassword ? <VisibilityOffIcon fontSize="small" /> : <VisibilityIcon fontSize="small" />}
+                        </IconButton>
+                      </Tooltip>
                     </InputAdornment>
                   )
                 }}


### PR DESCRIPTION
💡 **What:** Added Material-UI `Tooltip` components around icon-only buttons in the `ProfileClient` component (the "Edit" button and the "Show/Hide Password" toggle buttons).

🎯 **Why:** While the buttons had `aria-label` attributes for screen readers, sighted users had to guess the function of the icons (like the edit pencil or the eye for password visibility). Adding tooltips provides immediate visual feedback and improves usability and clarity.

♿ **Accessibility:** Sighted users now have hover labels. The `aria-label` attributes remain intact for screen reader compatibility.

---
*PR created automatically by Jules for task [4921159392200172071](https://jules.google.com/task/4921159392200172071) started by @matiasrozenblum*