### PR TITLE
🎨 Palette: Add Tooltips to YouTubeGlobalPlayer Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-06-09 - Added Tooltips to YouTubeGlobalPlayer buttons
+**Learning:** Tooltips on icon-only buttons improve usability for sighted users by providing a visual text alternative without requiring them to know the icon meaning, complementing the aria-label for screen readers.
+**Action:** Always wrap `IconButton` components with MUI `Tooltip` when possible.

--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Tooltip, useMediaQuery } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import { useYouTubePlayer } from '@/contexts/YouTubeGlobalPlayerContext';
@@ -224,17 +224,23 @@ export const YouTubeGlobalPlayer = () => {
           flexShrink: 0,
         }}>
           {minimized ? (
-            <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Maximizar reproductor" arrow>
+              <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           ) : (
-            <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Minimizar reproductor" arrow>
+              <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           )}
-          <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-            <CloseIcon fontSize="small" />
-          </IconButton>
+          <Tooltip title="Cerrar reproductor" arrow>
+            <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
         </Box>
 
         <Box sx={{ 


### PR DESCRIPTION
**💡 What**
Added MUI `Tooltip` wrappers to the icon-only buttons (Maximize, Minimize, Close) in the `YouTubeGlobalPlayer` component.

**🎯 Why**
Icon-only buttons can be difficult for sighted users to interpret, especially the generic "square" icon used for maximizing/minimizing. Adding tooltips provides a clear text alternative on hover, improving the overall usability and discoverability of these controls.

**📸 Before/After**
Before: The player controls were just icons with no hover text.
After: Hovering over the controls displays helpful text (e.g., "Maximizar reproductor").

**♿ Accessibility**
This change leverages the existing `aria-label` text to provide a visual tooltip (`Tooltip title="..."`), ensuring parity between the screen reader experience and the visual experience.

---
*PR created automatically by Jules for task [7452300888908134381](https://jules.google.com/task/7452300888908134381) started by @matiasrozenblum*