### PR TITLE
🎨 Palette: Add tooltips to YouTube player controls

### DIFF
--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Tooltip, useMediaQuery } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import { useYouTubePlayer } from '@/contexts/YouTubeGlobalPlayerContext';
@@ -224,17 +224,23 @@ export const YouTubeGlobalPlayer = () => {
           flexShrink: 0,
         }}>
           {minimized ? (
-            <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Maximizar" arrow>
+              <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           ) : (
-            <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Minimizar" arrow>
+              <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           )}
-          <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-            <CloseIcon fontSize="small" />
-          </IconButton>
+          <Tooltip title="Cerrar" arrow>
+            <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
         </Box>
 
         <Box sx={{ 


### PR DESCRIPTION
💡 **What**: Added `Tooltip` wrappers to the icon-only buttons (maximize, minimize, close) in the `YouTubeGlobalPlayer` component.
🎯 **Why**: Sighted users relying on a mouse can benefit from hover hints for icon-only buttons. The "CropSquareIcon" used for maximizing the player is not universally recognized; a clear Spanish tooltip ("Maximizar") eliminates ambiguity.
♿ **Accessibility**: Enhances the visual experience for mouse users while maintaining existing `aria-label`s for screen reader support.

---
*PR created automatically by Jules for task [6688913773628708025](https://jules.google.com/task/6688913773628708025) started by @matiasrozenblum*