### PR TITLE
feat: skeleton loading screen + branded error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ## [Unreleased]
 
 ### Added
-
-### Changed
+- Full-page skeleton loading screen (`HomePageSkeleton`) replaces the bare spinner shown during initial hydration. Matches the site layout: header bar, banner, day-selector pills, category tabs, time header, and 8 channel rows with program block placeholders. Uses deterministic block positions to avoid SSR hydration mismatches.
+- `src/app/loading.tsx`: Next.js streaming fallback — on cold starts the skeleton is sent to the browser immediately while `page.tsx` awaits backend data, eliminating the blank-tab experience.
+- `src/app/global-error.tsx`: standalone error page (provides its own `<html>`/`<body>`) for cases where the root layout itself fails (e.g. broken deploy). Embeds Inter font and all styles inline; uses `prefers-color-scheme` for dark mode since the layout's ThemeProvider is unavailable.
 
 ### Fixed
-
-### Deleted
+- Error page (`src/app/error.tsx`) rewritten with MUI components to match the site's design system (gradient background, Inter typography, themed buttons). Previous Tailwind-based version rendered unstyled because Tailwind's PostCSS pipeline does not compile classes for Next.js special-route files in this project's setup.
+- `ThemeContext` loading state: replaced `<CircularProgress />` with `<HomePageSkeleton />` wrapped in `MuiThemeProvider`, so the brief hydration phase renders a recognizable layout instead of a blank spinner.
 
 ---
 

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import { Box, Typography, Button, useTheme } from '@mui/material';
 
 export default function Error({
     error,
@@ -13,71 +14,103 @@ export default function Error({
         console.error('Unhandled app error:', error);
     }, [error]);
 
-    return (
-        <div className="min-h-[70vh] flex flex-col items-center justify-center p-6 text-center">
-            <div className="max-w-sm w-full flex flex-col items-center gap-6">
-                {/* Logo – theme-aware */}
-                <div>
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                        src="/img/text.png"
-                        alt="La Guía del Streaming"
-                        className="h-8 w-auto dark:hidden"
-                    />
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                        src="/img/text-white.png"
-                        alt="La Guía del Streaming"
-                        className="h-8 w-auto hidden dark:block"
-                    />
-                </div>
+    const theme = useTheme();
+    const isDark = theme.palette.mode === 'dark';
 
-                {/* Icon */}
-                <div className="w-20 h-20 bg-amber-100 dark:bg-amber-900/30 rounded-full flex items-center justify-center">
+    return (
+        <Box
+            sx={{
+                minHeight: '100dvh',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                p: 3,
+                background: isDark
+                    ? 'linear-gradient(135deg,#0f172a 0%,#1e293b 100%)'
+                    : 'linear-gradient(135deg,#f8fafc 0%,#e2e8f0 100%)',
+            }}
+        >
+            <Box
+                sx={{
+                    maxWidth: 380,
+                    width: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 3,
+                    textAlign: 'center',
+                }}
+            >
+                {/* Logo */}
+                <Box
+                    component="img"
+                    src={isDark ? '/img/text-white.png' : '/img/text.png'}
+                    alt="La Guía del Streaming"
+                    sx={{ height: 36, width: 'auto' }}
+                />
+
+                {/* Icon – amber wifi ring */}
+                <Box
+                    sx={{
+                        width: 80,
+                        height: 80,
+                        bgcolor: isDark ? 'rgba(245,158,11,0.15)' : '#fef3c7',
+                        borderRadius: '50%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        flexShrink: 0,
+                    }}
+                >
                     <svg
-                        className="w-10 h-10 text-amber-500 dark:text-amber-400"
+                        width="40"
+                        height="40"
                         fill="none"
-                        stroke="currentColor"
+                        stroke="#f59e0b"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
                         viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
                     >
-                        <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={1.5}
-                            d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"
-                        />
+                        <path d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0" />
                     </svg>
-                </div>
+                </Box>
 
                 {/* Text */}
-                <div className="space-y-2">
-                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+                <Box>
+                    <Typography variant="h5" fontWeight={700} gutterBottom>
                         Problemas técnicos
-                    </h1>
-                    <p className="text-gray-500 dark:text-gray-400 text-base leading-relaxed">
+                    </Typography>
+                    <Typography variant="body1" color="text.secondary">
                         Estamos teniendo inconvenientes técnicos.
                         <br />
                         El sitio estará disponible nuevamente en breve.
-                    </p>
-                </div>
+                    </Typography>
+                </Box>
 
-                {/* Actions */}
-                <div className="flex flex-col gap-3 w-full">
-                    <button
+                {/* Buttons */}
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, width: '100%' }}>
+                    <Button
+                        variant="contained"
+                        size="large"
+                        fullWidth
                         onClick={() => reset()}
-                        className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                        sx={{ borderRadius: 3, py: 1.5, fontWeight: 600 }}
                     >
                         Intentar de nuevo
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        size="large"
+                        fullWidth
                         onClick={() => window.location.reload()}
-                        className="w-full py-3 px-4 bg-transparent border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 font-medium rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2"
+                        sx={{ borderRadius: 3, py: 1.5, fontWeight: 600 }}
                     >
                         Recargar página
-                    </button>
-                </div>
-            </div>
-        </div>
+                    </Button>
+                </Box>
+            </Box>
+        </Box>
     );
 }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -10,39 +10,73 @@ export default function Error({
     reset: () => void;
 }) {
     useEffect(() => {
-        // Log the error
         console.error('Unhandled app error:', error);
     }, [error]);
 
     return (
-        <div className="min-h-[70vh] flex flex-col flex-1 items-center justify-center p-4 text-center">
-            <div className="max-w-md w-full bg-white dark:bg-gray-800 p-8 rounded-2xl shadow-lg border border-gray-100 dark:border-gray-700">
-                <div className="w-16 h-16 bg-red-100 dark:bg-red-900/30 rounded-full flex items-center justify-center mx-auto mb-6">
+        <div className="min-h-[70vh] flex flex-col items-center justify-center p-6 text-center">
+            <div className="max-w-sm w-full flex flex-col items-center gap-6">
+                {/* Logo – theme-aware */}
+                <div>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                        src="/img/text.png"
+                        alt="La Guía del Streaming"
+                        className="h-8 w-auto dark:hidden"
+                    />
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                        src="/img/text-white.png"
+                        alt="La Guía del Streaming"
+                        className="h-8 w-auto hidden dark:block"
+                    />
+                </div>
+
+                {/* Icon */}
+                <div className="w-20 h-20 bg-amber-100 dark:bg-amber-900/30 rounded-full flex items-center justify-center">
                     <svg
-                        className="w-8 h-8 text-red-600 dark:text-red-400"
+                        className="w-10 h-10 text-amber-500 dark:text-amber-400"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
                         xmlns="http://www.w3.org/2000/svg"
                     >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={1.5}
+                            d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"
+                        />
                     </svg>
                 </div>
 
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-                    ¡Algo salió mal!
-                </h2>
+                {/* Text */}
+                <div className="space-y-2">
+                    <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+                        Problemas técnicos
+                    </h1>
+                    <p className="text-gray-500 dark:text-gray-400 text-base leading-relaxed">
+                        Estamos teniendo inconvenientes técnicos.
+                        <br />
+                        El sitio estará disponible nuevamente en breve.
+                    </p>
+                </div>
 
-                <p className="text-gray-600 dark:text-gray-400 mb-8">
-                    Ocurrió un error inesperado de conexión o al cargar la página.
-                </p>
-
-                <button
-                    onClick={() => reset()}
-                    className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-                >
-                    Intentar de nuevo
-                </button>
+                {/* Actions */}
+                <div className="flex flex-col gap-3 w-full">
+                    <button
+                        onClick={() => reset()}
+                        className="w-full py-3 px-4 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-xl transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+                    >
+                        Intentar de nuevo
+                    </button>
+                    <button
+                        onClick={() => window.location.reload()}
+                        className="w-full py-3 px-4 bg-transparent border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 font-medium rounded-xl hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2"
+                    >
+                        Recargar página
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -5,7 +5,6 @@
 // Fonts and styles are embedded directly — do not rely on globals.css being loaded.
 
 export default function GlobalError({
-    error: _error,
     reset,
 }: {
     error: Error & { digest?: string };

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -5,7 +5,7 @@
 // Fonts and styles are embedded directly — do not rely on globals.css being loaded.
 
 export default function GlobalError({
-    error,
+    error: _error,
     reset,
 }: {
     error: Error & { digest?: string };

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+// global-error.tsx renders when the root layout itself fails.
+// It must provide its own <html> and <body> since the normal layout is bypassed.
+// Fonts and styles are embedded directly — do not rely on globals.css being loaded.
+
+export default function GlobalError({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string };
+    reset: () => void;
+}) {
+    return (
+        <html lang="es">
+            <head>
+                <meta charSet="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <title>Problemas técnicos – La Guía del Streaming</title>
+                <link
+                    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+                    rel="stylesheet"
+                />
+                <style>{`
+                    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+                    body {
+                        font-family: 'Inter', system-ui, sans-serif;
+                        background: #f8fafc;
+                        color: #111827;
+                        min-height: 100dvh;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        padding: 1.5rem;
+                    }
+                    .wrap {
+                        max-width: 360px;
+                        width: 100%;
+                        display: flex;
+                        flex-direction: column;
+                        align-items: center;
+                        gap: 1.5rem;
+                        text-align: center;
+                    }
+                    .logo { height: 32px; width: auto; }
+                    .icon-ring {
+                        width: 80px;
+                        height: 80px;
+                        background: #fef3c7;
+                        border-radius: 50%;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        flex-shrink: 0;
+                    }
+                    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.4rem; }
+                    .sub {
+                        color: #6b7280;
+                        font-size: 0.95rem;
+                        line-height: 1.65;
+                    }
+                    .actions { display: flex; flex-direction: column; gap: 0.75rem; width: 100%; }
+                    .btn {
+                        width: 100%;
+                        padding: 0.75rem 1rem;
+                        border-radius: 0.75rem;
+                        font-family: inherit;
+                        font-size: 0.925rem;
+                        font-weight: 500;
+                        cursor: pointer;
+                        transition: background 0.15s;
+                    }
+                    .btn-primary {
+                        background: #2563eb;
+                        color: #fff;
+                        border: none;
+                    }
+                    .btn-primary:hover { background: #1d4ed8; }
+                    .btn-secondary {
+                        background: transparent;
+                        color: #374151;
+                        border: 1px solid #e5e7eb;
+                    }
+                    .btn-secondary:hover { background: #f9fafb; }
+
+                    /* Dark mode via system preference */
+                    @media (prefers-color-scheme: dark) {
+                        body { background: #0f172a; color: #f1f5f9; }
+                        .icon-ring { background: rgba(217,119,6,0.2); }
+                        .sub { color: #94a3b8; }
+                        .btn-primary { background: #3b82f6; }
+                        .btn-primary:hover { background: #2563eb; }
+                        .btn-secondary { color: #cbd5e1; border-color: #334155; }
+                        .btn-secondary:hover { background: #1e293b; }
+                        .logo-light { display: none; }
+                    }
+                    @media (prefers-color-scheme: light) {
+                        .logo-dark { display: none; }
+                    }
+                `}</style>
+            </head>
+            <body>
+                <div className="wrap">
+                    <img
+                        src="/img/text.png"
+                        alt="La Guía del Streaming"
+                        className="logo logo-light"
+                    />
+                    <img
+                        src="/img/text-white.png"
+                        alt="La Guía del Streaming"
+                        className="logo logo-dark"
+                    />
+
+                    <div className="icon-ring">
+                        <svg
+                            width="40"
+                            height="40"
+                            fill="none"
+                            stroke="#f59e0b"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            viewBox="0 0 24 24"
+                        >
+                            <path d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0" />
+                        </svg>
+                    </div>
+
+                    <div>
+                        <h1>Problemas técnicos</h1>
+                        <p className="sub">
+                            Estamos teniendo inconvenientes técnicos.
+                            <br />
+                            El sitio estará disponible nuevamente en breve.
+                        </p>
+                    </div>
+
+                    <div className="actions">
+                        <button className="btn btn-primary" onClick={() => reset()}>
+                            Intentar de nuevo
+                        </button>
+                        <button
+                            className="btn btn-secondary"
+                            onClick={() => window.location.reload()}
+                        >
+                            Recargar página
+                        </button>
+                    </div>
+                </div>
+            </body>
+        </html>
+    );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+// Next.js streams this as the Suspense fallback while page.tsx is fetching data.
+// On cold starts (slow backend), the browser shows this skeleton immediately
+// instead of a blank tab, then transitions to the real content when SSR completes.
+import { HomePageSkeleton } from '@/components/HomePageSkeleton';
+
+export default function Loading() {
+  return <HomePageSkeleton />;
+}

--- a/src/components/HomePageSkeleton.tsx
+++ b/src/components/HomePageSkeleton.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React from 'react';
+import { Box, Skeleton, useTheme, useMediaQuery } from '@mui/material';
+import {
+  PIXELS_PER_MINUTE,
+  TIME_HEADER_HEIGHT,
+  ROW_HEIGHT,
+  CHANNEL_LABEL_WIDTH,
+} from '@/constants/layout';
+
+// Deterministic block positions – no Math.random() to avoid SSR hydration mismatches
+const BLOCK_PATTERNS = [
+  [{ left: '6%', width: '20%' }, { left: '40%', width: '25%' }],
+  [{ left: '3%', width: '28%' }, { left: '52%', width: '18%' }],
+  [{ left: '14%', width: '22%' }, { left: '48%', width: '22%' }],
+  [{ left: '8%', width: '18%' }, { left: '58%', width: '20%' }],
+  [{ left: '5%', width: '30%' }, { left: '45%', width: '15%' }],
+  [{ left: '10%', width: '24%' }, { left: '50%', width: '22%' }],
+  [{ left: '2%', width: '20%' }, { left: '38%', width: '28%' }],
+  [{ left: '12%', width: '26%' }, { left: '55%', width: '18%' }],
+];
+
+const DAYS = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
+const CATEGORIES_DESKTOP = 6;
+const CATEGORIES_MOBILE = 4;
+const ROW_COUNT = 8;
+const HOUR_COLUMNS = 10; // visible hour marks in the time header
+
+export function HomePageSkeleton() {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const channelLabelWidth = isMobile ? CHANNEL_LABEL_WIDTH.mobile : CHANNEL_LABEL_WIDTH.desktop;
+  const rowHeight = isMobile ? ROW_HEIGHT.mobile : ROW_HEIGHT.desktop;
+  const bannerHeight = isMobile ? 120 : 200;
+  const catCount = isMobile ? CATEGORIES_MOBILE : CATEGORIES_DESKTOP;
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        background:
+          theme.palette.mode === 'dark'
+            ? 'linear-gradient(135deg,#0f172a 0%,#1e293b 100%)'
+            : 'linear-gradient(135deg,#f8fafc 0%,#e2e8f0 100%)',
+        py: { xs: 1, sm: 2 },
+      }}
+    >
+      {/* ── Header ── */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          px: { xs: 2, sm: 3 },
+          mb: { xs: 1, sm: 1.5 },
+          flexShrink: 0,
+          gap: 1.5,
+        }}
+      >
+        {/* Logo icon */}
+        <Skeleton variant="circular" width={isMobile ? 32 : 42} height={isMobile ? 32 : 42} />
+        {/* Logo text */}
+        <Skeleton
+          variant="rectangular"
+          width={isMobile ? 96 : 130}
+          height={isMobile ? 28 : 36}
+          sx={{ borderRadius: 1 }}
+        />
+        <Box flex={1} />
+        {/* Nav tabs – desktop only */}
+        {!isMobile && (
+          <>
+            <Skeleton variant="rectangular" width={82} height={30} sx={{ borderRadius: 1 }} />
+            <Skeleton variant="rectangular" width={94} height={30} sx={{ borderRadius: 1 }} />
+            <Box flex={1} />
+          </>
+        )}
+        {/* Right icons */}
+        <Skeleton variant="circular" width={34} height={34} />
+        <Skeleton variant="circular" width={34} height={34} />
+      </Box>
+
+      {/* ── Banner ── */}
+      <Box
+        sx={{
+          px: { xs: 0, sm: 0 },
+          pb: { xs: 1, sm: 2 },
+          mx: { xs: 0, sm: 2 },
+          flexShrink: 0,
+        }}
+      >
+        <Skeleton
+          variant="rectangular"
+          width="100%"
+          height={bannerHeight}
+          sx={{ borderRadius: isMobile ? '12px' : '16px' }}
+        />
+      </Box>
+
+      {/* ── Schedule card (day buttons + tabs + grid) ── */}
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          mx: { xs: 0, sm: 2 },
+          display: 'flex',
+          flexDirection: 'column',
+          bgcolor: 'background.paper',
+          borderRadius: '12px 12px 0 0',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Day buttons */}
+        <Box
+          display="flex"
+          gap={1}
+          px={2}
+          pt={1.5}
+          pb={1}
+          sx={{ flexShrink: 0, overflow: 'hidden' }}
+        >
+          {DAYS.map((_, i) => (
+            <Skeleton
+              key={i}
+              variant="rectangular"
+              width={isMobile ? 40 : 76}
+              height={36}
+              sx={{ borderRadius: '18px', flexShrink: 0 }}
+            />
+          ))}
+        </Box>
+
+        {/* Category tabs */}
+        <Box
+          sx={{
+            borderBottom: `1px solid ${theme.palette.divider}`,
+            flexShrink: 0,
+          }}
+        >
+          <Box display="flex" gap={isMobile ? 0.5 : 1} px={2} pb={0.5}>
+            {Array.from({ length: catCount }).map((_, i) => (
+              <Skeleton
+                key={i}
+                variant="rectangular"
+                width={i === 0 ? 52 : isMobile ? 62 : 78}
+                height={34}
+                sx={{ borderRadius: 1 }}
+              />
+            ))}
+          </Box>
+        </Box>
+
+        {/* Time header */}
+        <Box
+          display="flex"
+          sx={{
+            height: TIME_HEADER_HEIGHT,
+            borderBottom: `1px solid ${theme.palette.divider}`,
+            flexShrink: 0,
+          }}
+        >
+          <Box
+            sx={{
+              width: channelLabelWidth,
+              minWidth: channelLabelWidth,
+              borderRight: `1px solid ${theme.palette.divider}`,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Skeleton variant="text" width={38} height={14} />
+          </Box>
+          <Box display="flex" flex={1} sx={{ overflow: 'hidden' }}>
+            {Array.from({ length: HOUR_COLUMNS }).map((_, i) => (
+              <Box
+                key={i}
+                sx={{
+                  width: PIXELS_PER_MINUTE * 60,
+                  flexShrink: 0,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  borderRight: `1px solid ${theme.palette.divider}`,
+                }}
+              >
+                <Skeleton variant="text" width={28} height={14} />
+              </Box>
+            ))}
+          </Box>
+        </Box>
+
+        {/* Channel rows */}
+        <Box sx={{ flex: 1, overflow: 'hidden' }}>
+          {Array.from({ length: ROW_COUNT }).map((_, r) => {
+            const blocks = BLOCK_PATTERNS[r % BLOCK_PATTERNS.length];
+            return (
+              <Box
+                key={r}
+                display="flex"
+                sx={{
+                  height: rowHeight,
+                  borderBottom: `1px solid ${theme.palette.divider}`,
+                }}
+              >
+                {/* Channel label */}
+                <Box
+                  sx={{
+                    width: channelLabelWidth,
+                    minWidth: channelLabelWidth,
+                    borderRight: `1px solid ${theme.palette.divider}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    px: 1,
+                    flexShrink: 0,
+                  }}
+                >
+                  <Skeleton
+                    variant="rectangular"
+                    width={channelLabelWidth * 0.65}
+                    height={rowHeight * 0.55}
+                    sx={{ borderRadius: 1 }}
+                  />
+                </Box>
+                {/* Program blocks */}
+                <Box sx={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+                  {blocks.map((b, bi) => (
+                    <Skeleton
+                      key={bi}
+                      variant="rectangular"
+                      animation="wave"
+                      sx={{
+                        position: 'absolute',
+                        top: '10%',
+                        left: b.left,
+                        width: b.width,
+                        height: '80%',
+                        borderRadius: 1,
+                      }}
+                    />
+                  ))}
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { createContext, useContext, useEffect, useState, useMemo } from 'react';
-import { ThemeProvider as MuiThemeProvider, createTheme, Theme, Box, CircularProgress, Components } from '@mui/material';
+import { ThemeProvider as MuiThemeProvider, createTheme, Theme, Box, Components } from '@mui/material';
+import { HomePageSkeleton } from '@/components/HomePageSkeleton';
 import type { ThemeOptions } from '@mui/material/styles';
 import { event as gaEvent } from '@/lib/gtag';
 
@@ -174,15 +175,11 @@ export const CustomThemeProvider = ({ children }: { children: React.ReactNode })
 
   if (!mounted) {
     return (
-      <Box 
-        display="flex" 
-        justifyContent="center" 
-        alignItems="center" 
-        minHeight="100dvh"
-        sx={{ backgroundColor: mode === 'light' ? '#f8fafc' : '#0f172a' }}
-      >
-        <CircularProgress />
-      </Box>
+      <MuiThemeProvider theme={theme}>
+        <Box sx={{ height: '100dvh', overflow: 'hidden' }}>
+          <HomePageSkeleton />
+        </Box>
+      </MuiThemeProvider>
     );
   }
 


### PR DESCRIPTION
## Summary

- **Skeleton loading screen:** replaces the bare spinner shown during hydration. `HomePageSkeleton` mirrors the full site layout: header, banner, day pills, category tabs, time header, 8 channel rows. Deterministic block positions avoid SSR hydration mismatches.
- **`loading.tsx`:** Next.js streaming fallback — skeleton is streamed immediately on cold starts while `page.tsx` awaits backend data, eliminating the blank-tab experience.
- **`error.tsx` redesign:** rewritten with MUI (was Tailwind, which doesn't compile for Next.js special-route files in this setup). Site gradient background, logo, amber wifi icon, Inter typography, MUI buttons.
- **`global-error.tsx`:** new standalone error page for root-layout failures. Embeds Inter font and styles inline; `prefers-color-scheme` for dark mode.

## Test plan

- [x] `npm run build` passes cleanly
- [x] TypeScript clean
- [ ] Verify skeleton on cold start in staging (incognito, hard refresh)
- [ ] Verify `error.tsx` locally: add `throw new Error('test')` to `HomePage()` in `page.tsx`, run `npm run dev`, visit `localhost:3000`
- [ ] `global-error.tsx` visible in production only (Next.js dev shows its own overlay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)