### PR TITLE
🎨 Palette: Add tooltips to YouTube global player controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2025-03-04 - Adding Tooltips to Global YouTube Player
+**Learning:** Icon-only buttons for critical video player controls (maximize, minimize, close) in floating dialogs need explicit `Tooltip` wrappers for sighted users. The `aria-label` provides a11y, but tooltips are essential for immediate UI comprehension in custom floating components like `YouTubeGlobalPlayer`.
+**Action:** Ensure all custom floating/modal components with icon-only actions wrap their `<IconButton>` components in `<Tooltip title="..." arrow>` matching the `aria-label`.

--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Tooltip, useMediaQuery } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import { useYouTubePlayer } from '@/contexts/YouTubeGlobalPlayerContext';
@@ -224,17 +224,23 @@ export const YouTubeGlobalPlayer = () => {
           flexShrink: 0,
         }}>
           {minimized ? (
-            <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Maximizar reproductor" arrow>
+              <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           ) : (
-            <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Minimizar reproductor" arrow>
+              <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           )}
-          <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-            <CloseIcon fontSize="small" />
-          </IconButton>
+          <Tooltip title="Cerrar reproductor" arrow>
+            <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
         </Box>
 
         <Box sx={{ 


### PR DESCRIPTION
💡 **What**: Added `Tooltip` wrappers from `@mui/material` to the maximize, minimize, and close icon buttons within `YouTubeGlobalPlayer.tsx`.
🎯 **Why**: While the buttons had `aria-label`s for screen readers, sighted users had no immediate visual cue to explain what the icons did (e.g. knowing if it closes vs minimizes).
📸 **Before/After**: The player now displays tooltips when hovering over the action buttons.
♿ **Accessibility**: Enhanced micro-UX usability for sighted users without affecting screen reader users since tooltips mirror the existing `aria-label`.

---
*PR created automatically by Jules for task [3495204286250629708](https://jules.google.com/task/3495204286250629708) started by @matiasrozenblum*