### PR TITLE
🎨 Palette: Add Tooltips to YouTube Global Player controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2024-05-15 - Missing tooltips on YouTube global player controls
+**Learning:** Found that the YouTube global player controls (maximize, minimize, close) lacked Tooltips. While they have `aria-label`s for screen readers, sighted users on desktop would benefit from visual tooltips explaining the ambiguous icon actions.
+**Action:** When adding icon-only `IconButton` components to an interface, especially those grouped tightly together, always wrap them in a Material UI `<Tooltip>` to ensure both screen reader accessibility and clear visual cues for sighted users.

--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, useMediaQuery } from '@mui/material';
+import { Box, IconButton, useMediaQuery, Tooltip } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import { useYouTubePlayer } from '@/contexts/YouTubeGlobalPlayerContext';
@@ -224,17 +224,23 @@ export const YouTubeGlobalPlayer = () => {
           flexShrink: 0,
         }}>
           {minimized ? (
-            <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Maximizar reproductor" arrow>
+              <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           ) : (
-            <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Minimizar reproductor" arrow>
+              <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           )}
-          <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-            <CloseIcon fontSize="small" />
-          </IconButton>
+          <Tooltip title="Cerrar reproductor" arrow>
+            <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
         </Box>
 
         <Box sx={{ 


### PR DESCRIPTION
💡 **What:** Added `<Tooltip>` wrappers around the maximize, minimize, and close `<IconButton>`s within the `YouTubeGlobalPlayer.tsx` component.
🎯 **Why:** To improve the UI by providing clear, visual labels for these icon-only buttons when hovered or focused by sighted users, particularly on desktop environments.
📸 **Before/After:** No visual changes unless hovering/focusing, then a tooltip is displayed.
♿ **Accessibility:** Re-used existing `aria-label`s for tooltip `title` props, keeping screen reader and visual cues consistent.

---
*PR created automatically by Jules for task [3644174488387929834](https://jules.google.com/task/3644174488387929834) started by @matiasrozenblum*