### PR TITLE
Release 1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 
+## [1.23.0] - 2026-06-18
+
+### Added
+- **Zapping between channels in the video player**: when the player is open and maximized, a toggle button (≡) reveals a side panel (desktop) or cards above/below (mobile) listing all currently-live channels. Clicking any channel zaps to it without closing the player.
+  - Desktop: `ZapSidePanel` — fixed-position sidebar to the left of the player (200 px wide, slides in/out with a 280 ms transition). Shows all live channels in grid order; the currently-playing channel is highlighted with a blue border and bold text. Auto-scrolls to center the current channel on open.
+  - Mobile: `ZapCard` — collapsible cards above/below the player showing up to 2 live channels from each direction. Animated with `max-height` transition.
+  - New `ZapItem` type (`src/types/zap.ts`) and `parseStreamUrl` utility (`src/utils/parseStreamUrl.ts`) to detect YouTube / Twitch / Kick URLs.
+  - `YouTubeGlobalPlayerContext` extended with `zapList`, `setZapList`, and `zapToChannel`.
+  - `HomeClient` derives the zap list from `channelsWithSchedules` + `liveStatus` (live channels only; current channel always included).
+  - Channel mini-logo and name shown in the player controls bar.
+
+### Fixed
+- Overflow zone: programs with `start_time = "00:00"` on the next day are no longer injected into the current day's overflow zone. They appeared flush against the right edge of cross-midnight blocks (which end at 24:00), creating a visual duplicate. These programs now only appear when viewing their own day. (`ScheduleGridDesktop`, `ScheduleGridMobile`)
+- Overflow zone: added `positionOffset` to the React `Fragment` key in `ScheduleRow` (`scheduleId|programId|positionOffset`). The same schedule could appear as an overflow block (positionOffset=1440) on day X and as a current-day block (positionOffset=0) on day X+1 — React reused the component instance, causing the previous day's block color to persist via the `background-color` CSS transition.
+- Double tooltip on same-program multiple slots: `tooltipId` in `ProgramBlock` was keyed by `program.id`, shared across all schedule entries for the same program. Hovering either slot opened both tooltips simultaneously. Fixed by including `start_time` in the ID (`program-${id}-${start}`).
+
+---
+
 ## [1.22.0] - 2026-06-14
 
 ### Added

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -11,12 +11,14 @@ import { api } from '@/services/api';
 import { bannersApi } from '@/services/banners';
 import { useLiveStatus } from '@/contexts/LiveStatusContext';
 import { useThemeContext } from '@/contexts/ThemeContext';
+import { useYouTubePlayer } from '@/contexts/YouTubeGlobalPlayerContext';
 import { ScheduleGrid } from '@/components/ScheduleGrid';
 import { SkeletonScheduleGrid } from '@/components/SkeletonScheduleGrid';
 import BannerCarousel from '@/components/BannerCarousel';
 import type { ChannelWithSchedules, Category } from '@/types/channel';
 import type { Schedule } from '@/types/schedule';
 import type { Banner } from '@/types/banner';
+import type { ZapItem } from '@/types/zap';
 import Header from './Header';
 import BottomNavigation from './BottomNavigation';
 import { useDeviceId } from '@/hooks/useDeviceId';
@@ -24,6 +26,8 @@ import { event as gaEvent } from '@/lib/gtag';
 import { useSessionContext } from '@/contexts/SessionContext';
 import type { SessionWithToken } from '@/types/session';
 import { isBeforeInBuenosAires, getNextMondayDate } from '@/utils/date';
+import { parseStreamUrl } from '@/utils/parseStreamUrl';
+import dayjs from 'dayjs';
 
 
 const HolidayDialog = dynamic(() => import('@/components/HolidayDialog'), { ssr: false });
@@ -62,7 +66,8 @@ export default function HomeClient({ initialData }: HomeClientProps) {
   const bannerContainerRef = useRef<HTMLDivElement>(null);
 
   const { mode } = useThemeContext();
-  const { setLiveStatuses } = useLiveStatus();
+  const { setLiveStatuses, liveStatus } = useLiveStatus();
+  const { setZapList } = useYouTubePlayer();
 
   // Populate live status context with initial data synchronously
   const initialLiveMap = useMemo(() => {
@@ -193,6 +198,60 @@ export default function HomeClient({ initialData }: HomeClientProps) {
   );
 
   const showSkeleton = flattened.length === 0;
+
+  // Build the channel list used by the zapping feature in the player
+  const zapList = useMemo((): ZapItem[] => {
+    const today = dayjs().format('dddd').toLowerCase();
+
+    return channelsWithSchedules.map(cws => {
+      const { channel, schedules } = cws;
+
+      let videoUrl: string | null = null;
+      let isLive = false;
+      let programName: string | null = null;
+
+      // Prefer a currently-live program from today's schedules
+      const todaySchedules = schedules.filter(s => s.day_of_week === today);
+      for (const s of todaySchedules) {
+        const liveData = liveStatus[s.id.toString()];
+        const streamUrl = liveData?.stream_url || s.program.stream_url;
+        const live = liveData?.is_live ?? s.program.is_live;
+        if (streamUrl && live) {
+          videoUrl = streamUrl;
+          isLive = true;
+          programName = s.program.name;
+          break;
+        }
+      }
+
+      // Fall back to any schedule that has a stream URL
+      if (!videoUrl) {
+        for (const s of schedules) {
+          if (s.program.stream_url) {
+            videoUrl = s.program.stream_url;
+            break;
+          }
+        }
+      }
+
+      const service = videoUrl ? (parseStreamUrl(videoUrl)?.service ?? null) : null;
+
+      return {
+        id: channel.id,
+        name: channel.name,
+        logoUrl: channel.logo_url,
+        backgroundColor: channel.background_color,
+        videoUrl,
+        service,
+        isLive,
+        programName,
+      };
+    });
+  }, [channelsWithSchedules, liveStatus]);
+
+  useEffect(() => {
+    setZapList(zapList);
+  }, [zapList, setZapList]);
 
   useEffect(() => {
     if (!deviceId) return; // Only wait for deviceId

--- a/src/components/ProgramBlock.tsx
+++ b/src/components/ProgramBlock.tsx
@@ -8,8 +8,8 @@ import { useLayoutValues, DAY_WITH_OVERFLOW_WIDTH_PX } from '@/constants/layout'
 import { OpenInNew, Notifications } from '@mui/icons-material';
 import { useThemeContext } from '@/contexts/ThemeContext';
 import { useYouTubePlayer } from '@/contexts/YouTubeGlobalPlayerContext';
+import { parseStreamUrl } from '@/utils/parseStreamUrl';
 import { event as gaEvent } from '@/lib/gtag';
-import { extractVideoId } from '@/utils/extractVideoId';
 import { tokens } from '@/design-system/tokens';
 import { Text, BaseButton } from '@/design-system/components';
 import { api } from '@/services/api';
@@ -37,7 +37,10 @@ interface Props {
   panelists?: { id: string; name: string }[];
   logo_url?: string;
   color?: string;
+  channelId?: number;
   channelName: string;
+  channelLogo?: string | null;
+  channelBackgroundColor?: string | null;
   isToday?: boolean;
   is_live?: boolean;
   stream_url?: string | null;
@@ -61,7 +64,10 @@ export const ProgramBlock: React.FC<Props> = ({
   panelists,
   logo_url,
   color = '#2196F3',
+  channelId,
   channelName,
+  channelLogo,
+  channelBackgroundColor,
   isToday,
   is_live,
   stream_url,
@@ -85,7 +91,7 @@ export const ProgramBlock: React.FC<Props> = ({
   const bellRef = useRef<HTMLButtonElement>(null);
   const [isOn, setIsOn] = useState(subscribed);
   const [isLoading, setIsLoading] = useState(false);
-  const { openVideo, openPlaylist } = useYouTubePlayer();
+  const { openVideo, openPlaylist, openStream } = useYouTubePlayer();
   const { subscribeAndRegister, isPWAInstalled } = usePush();
   const { openTooltip: globalOpenTooltip, closeTooltip: globalCloseTooltip, isTooltipOpen } = useTooltip();
   // Removed showSecondaryStreams - no longer needed
@@ -99,7 +105,8 @@ export const ProgramBlock: React.FC<Props> = ({
   const [blockWidth, setBlockWidth] = useState<number | null>(null);
   const [mousePosition, setMousePosition] = useState<{ x: number; y: number } | null>(null);
 
-  const tooltipId = `program-${id}`;
+  // Include start time so two slots of the same program get distinct tooltip IDs
+  const tooltipId = `program-${id}-${start}`;
   const isTooltipOpenForThis = isTooltipOpen(tooltipId);
 
   // Style override logic
@@ -188,20 +195,22 @@ export const ProgramBlock: React.FC<Props> = ({
       userData: typedSession?.user
     });
 
-    try {
-      const url = new URL(streamUrl);
-      const listId = url.searchParams.get('list');
-      if (listId) {
-        openPlaylist(listId);
-        return;
-      }
-    } catch {
-      // Ignorar URL inválida
-    }
+    const channelInfo = channelId
+      ? { channelId, channelName, channelLogo, channelBackgroundColor }
+      : undefined;
 
-    const videoId = extractVideoId(streamUrl);
-    if (videoId) {
-      openVideo(videoId);
+    const parsed = parseStreamUrl(streamUrl);
+    if (!parsed) return;
+
+    if (parsed.service === 'youtube') {
+      if (parsed.embedPath.startsWith('videoseries?list=')) {
+        const listId = parsed.embedPath.replace('videoseries?list=', '');
+        openPlaylist(listId, channelInfo);
+      } else {
+        openVideo(parsed.embedPath, channelInfo);
+      }
+    } else {
+      openStream(parsed.service, parsed.embedPath, channelInfo);
     }
   };
 

--- a/src/components/ScheduleGridDesktop.tsx
+++ b/src/components/ScheduleGridDesktop.tsx
@@ -159,7 +159,11 @@ export const ScheduleGridDesktop = ({ channels, schedules, categories, categorie
   const schedulesForOverflow = overflowSource.filter(s => {
     if (s.day_of_week !== nextDay) return false;
     const [h, m] = s.start_time.split(':').map(Number);
-    return (h * 60 + m) < OVERFLOW_MINUTES;
+    const startMin = h * 60 + m;
+    // Exclude start_time="00:00": midnight-boundary programs sit flush against
+    // the right edge of cross-midnight current-day blocks and look duplicated.
+    // They belong to the next day's own view, not to the current day's overflow.
+    return startMin > 0 && startMin < OVERFLOW_MINUTES;
   });
 
   const getSchedulesForChannel = (id: number) => [
@@ -340,6 +344,7 @@ export const ScheduleGridDesktop = ({ channels, schedules, categories, categorie
           {visibleChannels.map((channel, idx) => (
             <ScheduleRow
               key={channel.id}
+              channelId={channel.id}
               channelName={channel.name}
               channelLogo={channel.logo_url || undefined}
               channelBackgroundColor={channel.background_color}

--- a/src/components/ScheduleGridMobile.tsx
+++ b/src/components/ScheduleGridMobile.tsx
@@ -151,7 +151,11 @@ export const ScheduleGridMobile = ({ channels, schedules, categories, categories
   const schedulesForOverflow = overflowSource.filter(s => {
     if (s.day_of_week !== nextDay) return false;
     const [h, m] = s.start_time.split(':').map(Number);
-    return (h * 60 + m) < OVERFLOW_MINUTES;
+    const startMin = h * 60 + m;
+    // Exclude start_time="00:00": midnight-boundary programs sit flush against
+    // the right edge of cross-midnight current-day blocks and look duplicated.
+    // They belong to the next day's own view, not to the current day's overflow.
+    return startMin > 0 && startMin < OVERFLOW_MINUTES;
   });
 
   const getSchedulesForChannel = (channelId: number) => [
@@ -297,6 +301,7 @@ export const ScheduleGridMobile = ({ channels, schedules, categories, categories
           {visibleChannels.map((channel, idx) => (
             <ScheduleRow
               key={channel.id}
+              channelId={channel.id}
               channelName={channel.name}
               channelLogo={channel.logo_url || undefined}
               channelBackgroundColor={channel.background_color}

--- a/src/components/ScheduleRow.tsx
+++ b/src/components/ScheduleRow.tsx
@@ -82,6 +82,7 @@ interface Program {
 }
 
 interface Props {
+  channelId?: number;
   channelName: string;
   channelLogo?: string;
   channelBackgroundColor?: string | null;
@@ -91,6 +92,7 @@ interface Props {
 }
 
 export const ScheduleRow = ({
+  channelId,
   channelName,
   channelLogo,
   channelBackgroundColor,
@@ -366,7 +368,7 @@ export const ScheduleRow = ({
             const hasTimeOverlap = laneIndex !== undefined;
 
             return (
-              <React.Fragment key={`${p.scheduleId}|${p.id}`}>
+              <React.Fragment key={`${p.scheduleId}|${p.id}|${p.positionOffset ?? 0}`}>
                 <ProgramBlock
                   id={p.id}
                   name={p.name}
@@ -376,7 +378,10 @@ export const ScheduleRow = ({
                   description={p.description}
                   panelists={p.panelists}
                   logo_url={p.logo_url}
+                  channelId={channelId}
                   channelName={channelName}
+                  channelLogo={channelLogo}
+                  channelBackgroundColor={channelBackgroundColor}
                   color={color}
                   isToday={isToday}
                   stream_url={currentStreamUrl}

--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,19 +1,40 @@
 'use client';
 
-import { Box, IconButton, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Typography, useMediaQuery } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import { useYouTubePlayer } from '@/contexts/YouTubeGlobalPlayerContext';
-import { useEffect, useRef, useState, useCallback } from 'react';
-import { useTheme } from '@mui/material/styles';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { ZapCard } from './ZapCard';
+import { ZapSidePanel } from './ZapSidePanel';
+
+const PLAYER_HEIGHT_DESKTOP = 500;
+
+function getLogoBg(bg?: string | null): React.CSSProperties {
+  if (!bg) return { backgroundColor: '#FFFFFF' };
+  if (bg.startsWith('linear-gradient')) return { background: bg };
+  if (bg.includes('gradient')) return { backgroundColor: '#FFFFFF' };
+  return { backgroundColor: bg };
+}
 
 export const YouTubeGlobalPlayer = () => {
-  const { playerData, open, minimized, closePlayer, minimizePlayer, maximizePlayer } = useYouTubePlayer();
+  const {
+    playerData,
+    open,
+    minimized,
+    zapList,
+    closePlayer,
+    minimizePlayer,
+    maximizePlayer,
+    zapToChannel,
+  } = useYouTubePlayer();
+
   const isMobile = useMediaQuery('(max-width:600px)');
-  const theme = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [dragging, setDragging] = useState(false);
+  const [zapOpen, setZapOpen] = useState(false);
   const offset = useRef({ x: 0, y: 0 });
 
   const minimizedWidth = isMobile ? 300 : 340;
@@ -21,79 +42,101 @@ export const YouTubeGlobalPlayer = () => {
   const margin = 20;
   const paddingCompensation = 32;
 
-  const buttonBgColor = theme.palette.mode === 'dark' ? '#1e293b' : '#f5f5f5';
+  useEffect(() => {
+    if (minimized) setZapOpen(false);
+  }, [minimized]);
 
-  const moveTo = useCallback((clientX: number, clientY: number) => {
-    if (!dragging) return;
-    
-    const clampedX = Math.max(0, Math.min(clientX - offset.current.x, window.innerWidth - minimizedWidth));
-    const clampedY = Math.max(0, Math.min(clientY - offset.current.y, window.innerHeight - minimizedHeight));
-    
-    setPosition({ x: clampedX, y: clampedY });
-  }, [dragging, minimizedWidth, minimizedHeight]);
-  
+  useEffect(() => {
+    if (!open) setZapOpen(false);
+  }, [open]);
+
+  const { aboveItems, belowItems, panelItems, currentChannelId } = useMemo(() => {
+    const currentId = playerData?.channelInfo?.channelId;
+    // Only channels currently airing live are zappable — the current channel is
+    // always included regardless of its live state, since it's actively playing.
+    const isZappable = (z: typeof zapList[number]) => (z.isLive && z.videoUrl !== null) || z.id === currentId;
+
+    const panelItems = zapList.filter(isZappable);
+
+    if (!currentId) return { aboveItems: [], belowItems: [], panelItems, currentChannelId: undefined };
+
+    const idx = zapList.findIndex((z) => z.id === currentId);
+    if (idx === -1) return { aboveItems: [], belowItems: zapList.filter(isZappable), panelItems, currentChannelId: currentId };
+
+    // Mobile cards: split at current channel index (current channel itself not shown in cards)
+    const above = zapList.slice(0, idx).filter(isZappable);
+    const below = zapList.slice(idx + 1).filter(isZappable);
+    return { aboveItems: above, belowItems: below, panelItems, currentChannelId: currentId };
+  }, [zapList, playerData?.channelInfo?.channelId]);
+
+  const hasZapItems = panelItems.length > 1 || aboveItems.length > 0 || belowItems.length > 0;
+
+  const moveTo = useCallback(
+    (clientX: number, clientY: number) => {
+      if (!dragging) return;
+      const clampedX = Math.max(0, Math.min(clientX - offset.current.x, window.innerWidth - minimizedWidth));
+      const clampedY = Math.max(0, Math.min(clientY - offset.current.y, window.innerHeight - minimizedHeight));
+      setPosition({ x: clampedX, y: clampedY });
+    },
+    [dragging, minimizedWidth, minimizedHeight],
+  );
+
   const handleMouseUp = useCallback(() => {
-    if (dragging) {
-      setDragging(false);
-    }
+    if (dragging) setDragging(false);
   }, [dragging]);
-  
-  const handleMouseMove = useCallback((e: MouseEvent) => {
-    moveTo(e.clientX, e.clientY);
-  }, [moveTo]);
-  
-  const handleTouchMove = useCallback((e: TouchEvent) => {
-    if (!dragging) return;
-    e.preventDefault();
-    const touch = e.touches[0];
-    moveTo(touch.clientX, touch.clientY);
-  }, [dragging, moveTo]);
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => moveTo(e.clientX, e.clientY),
+    [moveTo],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (!dragging) return;
+      e.preventDefault();
+      const touch = e.touches[0];
+      moveTo(touch.clientX, touch.clientY);
+    },
+    [dragging, moveTo],
+  );
 
   useEffect(() => {
     if (minimized) {
-      if (isMobile) {
-        setPosition({
-          x: (window.innerWidth - minimizedWidth) / 2,
-          y: window.innerHeight - minimizedHeight - margin - paddingCompensation,
-        });
-      } else {
-        setPosition({
-          x: window.innerWidth - minimizedWidth - margin,
-          y: window.innerHeight - minimizedHeight - margin - paddingCompensation,
-        });
-      }
+      setPosition(
+        isMobile
+          ? {
+              x: (window.innerWidth - minimizedWidth) / 2,
+              y: window.innerHeight - minimizedHeight - margin - paddingCompensation,
+            }
+          : {
+              x: window.innerWidth - minimizedWidth - margin,
+              y: window.innerHeight - minimizedHeight - margin - paddingCompensation,
+            },
+      );
     }
   }, [minimized, isMobile, minimizedWidth, minimizedHeight]);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!minimized) return;
     if ((e.target as HTMLElement).closest('button')) return;
     setDragging(true);
-    offset.current = {
-      x: e.clientX - position.x,
-      y: e.clientY - position.y,
-    };
+    offset.current = { x: e.clientX - position.x, y: e.clientY - position.y };
   };
 
   const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    if (!minimized) return;
     if ((e.target as HTMLElement).closest('button')) return;
     const touch = e.touches[0];
     setDragging(true);
-    offset.current = {
-      x: touch.clientX - position.x,
-      y: touch.clientY - position.y,
-    };
+    offset.current = { x: touch.clientX - position.x, y: touch.clientY - position.y };
   };
 
   useEffect(() => {
-    if (!open) return;
-
-    if (dragging) {
-      window.addEventListener('mousemove', handleMouseMove);
-      window.addEventListener('mouseup', handleMouseUp);
-      window.addEventListener('touchmove', handleTouchMove, { passive: false });
-      window.addEventListener('touchend', handleMouseUp);
-    }
-
+    if (!open || !dragging) return;
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    window.addEventListener('touchmove', handleTouchMove, { passive: false });
+    window.addEventListener('touchend', handleMouseUp);
     return () => {
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('mouseup', handleMouseUp);
@@ -103,94 +146,115 @@ export const YouTubeGlobalPlayer = () => {
   }, [dragging, open, handleMouseMove, handleMouseUp, handleTouchMove]);
 
   useEffect(() => {
-    const handleTouchMove = (e: TouchEvent) => {
-      e.preventDefault();
-    };
-  
-    if (dragging) {
-      document.addEventListener('touchmove', handleTouchMove, { passive: false });
-    }
-  
-    return () => {
-      document.removeEventListener('touchmove', handleTouchMove);
-    };
+    const handler = (e: TouchEvent) => e.preventDefault();
+    if (dragging) document.addEventListener('touchmove', handler, { passive: false });
+    return () => document.removeEventListener('touchmove', handler);
   }, [dragging]);
 
   if (!open || !playerData) return null;
 
-  // Build embed URL based on service type
-  // NOTE: Do NOT add enablejsapi=1 — this flag enables the YouTube IFrame API and
-  // causes the player to send periodic heartbeat postMessages to the parent frame.
-  // Since this component has no YouTube API code to respond, the player detects an
-  // unresponsive channel after ~3 minutes and freezes/blanks the video.
+  // Build embed src.
+  // NOTE: Do NOT add enablejsapi=1 — causes heartbeat postMessages that freeze player after ~3 min.
   let src = '';
   if (playerData.service === 'youtube') {
     const baseUrl = `https://www.youtube.com/embed/${playerData.embedPath}`;
-    src = playerData.embedPath.includes('?')
-      ? `${baseUrl}&autoplay=1`
-      : `${baseUrl}?autoplay=1`;
+    src = playerData.embedPath.includes('?') ? `${baseUrl}&autoplay=1` : `${baseUrl}?autoplay=1`;
   } else if (playerData.service === 'twitch') {
-    // Twitch embed requires parent domain for security
     const parent = typeof window !== 'undefined' ? window.location.hostname : '';
     src = `https://player.twitch.tv/?channel=${playerData.embedPath}&parent=${parent}&autoplay=true`;
   } else if (playerData.service === 'kick') {
     src = `https://player.kick.com/${playerData.embedPath}?autoplay=true`;
   }
 
-  // Determine if this is a streaming service (Twitch/Kick) that benefits from larger mobile popup
   const isStreamingService = playerData.service === 'twitch' || playerData.service === 'kick';
-  
-  // Calculate responsive dimensions
-  const getPopupDimensions = () => {
-    if (minimized) {
-      return {
-        width: minimizedWidth,
-        height: minimizedHeight,
-      };
-    }
-    
-    if (isMobile) {
-      // Mobile: 95% width, height calculated to maintain ~16:9 aspect ratio
-      // Account for padding (8px top + 8px bottom = 16px) and controls (~40px)
-      // For 95% width, approximate 16:9 height would be: width * (9/16)
-      // Using viewport width as reference: vw * 0.95 * (9/16) ≈ 53.4vw
-      // But we use vh for consistency, targeting ~50-55vh for better aspect ratio
-      return {
-        width: '95%',
-        height: isStreamingService ? '54vh' : '52vh',
-      };
-    }
-    
-    // Desktop: keep current dimensions
-    return {
-      width: '80%',
-      maxWidth: 800,
-      height: 500,
-    };
+
+  const getDimensions = () => {
+    if (minimized) return { width: minimizedWidth, height: minimizedHeight };
+    if (isMobile) return { width: '95%', height: isStreamingService ? '54vh' : '52vh' };
+    return { width: '80%', maxWidth: 800, height: PLAYER_HEIGHT_DESKTOP };
   };
 
-  const dimensions = getPopupDimensions();
+  const dimensions = getDimensions();
+
+  // Side panel open state (desktop only)
+  const sidePanelOpen = !isMobile && zapOpen && hasZapItems && !minimized;
+
+  // Mobile cards
+  const upperVisible = isMobile && zapOpen && aboveItems.length > 0 && !minimized;
+  const lowerVisible = isMobile && zapOpen && belowItems.length > 0 && !minimized;
+
+  const playerBorderRadius = minimized
+    ? '12px'
+    : isMobile
+      ? `${upperVisible ? 0 : 12}px ${upperVisible ? 0 : 12}px ${lowerVisible ? 0 : 12}px ${lowerVisible ? 0 : 12}px`
+      : `${sidePanelOpen ? 0 : 12}px 12px 12px ${sidePanelOpen ? 0 : 12}px`;
+
+  const channelInfo = playerData.channelInfo;
 
   return (
     <>
-      {minimized && dragging && (
-         <Box
-         onTouchStart={(e) => e.preventDefault()}
-         onTouchMove={(e) => e.preventDefault()}
-         onTouchEnd={(e) => e.preventDefault()}
-         onMouseDown={(e) => e.preventDefault()}
-         sx={{
-           position: 'fixed',
-           top: 0,
-           left: 0,
-           width: '100vw',
-           height: '100dvh',
-           backgroundColor: 'rgba(0, 0, 0, 0.2)',
-           zIndex: 1999,
-         }}
-       />
+      {/* Dark overlay for maximized state */}
+      {!minimized && (
+        <Box
+          onClick={closePlayer}
+          sx={{ position: 'fixed', inset: 0, bgcolor: 'rgba(0,0,0,0.75)', zIndex: 1999 }}
+        />
       )}
 
+      {/* Drag capture overlay (minimized + dragging) */}
+      {minimized && dragging && (
+        <Box
+          onTouchStart={(e) => e.preventDefault()}
+          onTouchMove={(e) => e.preventDefault()}
+          onTouchEnd={(e) => e.preventDefault()}
+          onMouseDown={(e) => e.preventDefault()}
+          sx={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            width: '100vw',
+            height: '100dvh',
+            backgroundColor: 'rgba(0,0,0,0.2)',
+            zIndex: 1999,
+          }}
+        />
+      )}
+
+      {/*
+        Desktop side panel: separate fixed element, positioned so its right edge
+        aligns with the player's left edge.
+        Player center: left 50%, translate(-50%). Player half-width = min(40vw, 400px).
+        Player left edge from viewport right = 50vw + min(40vw, 400px).
+        → panel right: calc(50% + min(40vw, 400px))
+      */}
+      {!minimized && !isMobile && (
+        <Box
+          onWheel={(e) => e.stopPropagation()}
+          onTouchMove={(e) => e.stopPropagation()}
+          sx={{
+            position: 'fixed',
+            top: '50%',
+            right: 'calc(50% + min(40vw, 400px))',
+            transform: 'translateY(-50%)',
+            height: `${PLAYER_HEIGHT_DESKTOP}px`,
+            width: sidePanelOpen ? '200px' : 0,
+            overflow: 'hidden',
+            transition: 'width 280ms cubic-bezier(0.4, 0, 0.2, 1)',
+            pointerEvents: sidePanelOpen ? 'auto' : 'none',
+            zIndex: 2000,
+          }}
+        >
+          <ZapSidePanel
+            items={panelItems}
+            currentId={currentChannelId}
+            isOpen={sidePanelOpen}
+            playerHeight={PLAYER_HEIGHT_DESKTOP}
+            onZap={zapToChannel}
+          />
+        </Box>
+      )}
+
+      {/* Main player outer wrapper — always flex-column, same layout as pre-zap */}
       <Box
         ref={containerRef}
         onMouseDown={handleMouseDown}
@@ -201,59 +265,138 @@ export const YouTubeGlobalPlayer = () => {
           left: minimized ? position.x : '50%',
           transform: minimized ? 'none' : 'translate(-50%, -50%)',
           width: dimensions.width,
-          maxWidth: dimensions.maxWidth,
-          height: dimensions.height,
-          bgcolor: 'background.paper',
-          borderRadius: 3,
-          boxShadow: 24,
-          p: isMobile && !minimized ? 1 : 2, // Reduced padding on mobile (8px vs 16px)
-          overflow: 'hidden',
+          maxWidth: (dimensions as { maxWidth?: number }).maxWidth,
           zIndex: 2000,
-          userSelect: 'none',
-          cursor: dragging ? 'grabbing' : 'default',
           display: 'flex',
           flexDirection: 'column',
-          transition: 'all 0.3s ease',
+          userSelect: 'none',
+          cursor: dragging ? 'grabbing' : 'default',
         }}
       >
-        <Box sx={{ 
-          display: 'flex', 
-          justifyContent: 'flex-end', 
-          mb: isMobile && !minimized ? 0.5 : 1, 
-          gap: 1,
-          flexShrink: 0,
-        }}>
-          {minimized ? (
-            <IconButton aria-label="Maximizar reproductor" onClick={maximizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
+        {/* Mobile: card above player */}
+        {!minimized && isMobile && (
+          <ZapCard items={aboveItems} position="above" isOpen={zapOpen} onZap={zapToChannel} />
+        )}
+
+        {/* Player box */}
+        <Box
+          sx={{
+            bgcolor: '#1E293B',
+            borderRadius: playerBorderRadius,
+            boxShadow: 24,
+            p: isMobile && !minimized ? 1 : 2,
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            height: dimensions.height,
+            transition: 'border-radius 200ms ease',
+          }}
+        >
+          {/* Controls bar */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              mb: isMobile && !minimized ? 0.5 : 1,
+              gap: 0.5,
+              flexShrink: 0,
+            }}
+          >
+            {/* Zap toggle */}
+            {!minimized && hasZapItems && (
+              <IconButton
+                aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
+                onClick={() => setZapOpen((v) => !v)}
+                size="small"
+                sx={{
+                  color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
+                  '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
+                }}
+              >
+                <FormatListBulletedIcon fontSize="small" />
+              </IconButton>
+            )}
+
+            {/* Channel mini-logo + name */}
+            {!minimized && channelInfo && (
+              <>
+                <Box
+                  sx={{
+                    width: 44,
+                    height: 22,
+                    borderRadius: '4px',
+                    overflow: 'hidden',
+                    flexShrink: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    ...getLogoBg(channelInfo.channelBackgroundColor),
+                  }}
+                >
+                  {channelInfo.channelLogo && (
+                    <Box
+                      component="img"
+                      src={channelInfo.channelLogo}
+                      alt={channelInfo.channelName}
+                      sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
+                    />
+                  )}
+                </Box>
+                <Typography
+                  sx={{
+                    color: '#e2e8f0',
+                    fontSize: '13px',
+                    fontWeight: 600,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: 180,
+                  }}
+                >
+                  {channelInfo.channelName}
+                </Typography>
+              </>
+            )}
+
+            <Box sx={{ flex: 1 }} />
+
+            <IconButton
+              aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
+              onClick={minimized ? maximizePlayer : minimizePlayer}
+              size="small"
+              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+            >
               <CropSquareIcon fontSize="small" />
             </IconButton>
-          ) : (
-            <IconButton aria-label="Minimizar reproductor" onClick={minimizePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-              <CropSquareIcon fontSize="small" />
+
+            <IconButton
+              aria-label="Cerrar reproductor"
+              onClick={closePlayer}
+              size="small"
+              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+            >
+              <CloseIcon fontSize="small" />
             </IconButton>
-          )}
-          <IconButton aria-label="Cerrar reproductor" onClick={closePlayer} size="small" sx={{ bgcolor: buttonBgColor }}>
-            <CloseIcon fontSize="small" />
-          </IconButton>
+          </Box>
+
+          {/* iframe */}
+          <Box sx={{ flexGrow: 1, width: '100%', borderRadius: 2, overflow: 'hidden', minHeight: 0 }}>
+            <iframe
+              width="100%"
+              height="100%"
+              src={src}
+              frameBorder="0"
+              allow="autoplay; encrypted-media"
+              allowFullScreen
+              style={{ borderRadius: 8 }}
+            />
+          </Box>
         </Box>
 
-        <Box sx={{ 
-          flexGrow: 1, 
-          width: '100%', 
-          borderRadius: 2, 
-          overflow: 'hidden',
-          minHeight: 0, // Important for flex children to shrink properly
-        }}>
-          <iframe
-            width="100%"
-            height="100%"
-            src={src}
-            frameBorder="0"
-            allow="autoplay; encrypted-media"
-            allowFullScreen
-            style={{ borderRadius: 8 }}
-          />
-        </Box>
+        {/* Mobile: card below player */}
+        {!minimized && isMobile && (
+          <ZapCard items={belowItems} position="below" isOpen={zapOpen} onZap={zapToChannel} />
+        )}
       </Box>
     </>
   );

--- a/src/components/ZapCard.tsx
+++ b/src/components/ZapCard.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { Box, Typography } from '@mui/material';
+import type { ZapItem } from '@/types/zap';
+
+const ROW_HEIGHT = 64;
+const MAX_VISIBLE_ROWS = 2;
+const CARD_MAX_HEIGHT = ROW_HEIGHT * MAX_VISIBLE_ROWS;
+const CARD_BG = '#1E293B';
+
+function getLogoBg(bg?: string | null): React.CSSProperties {
+  if (!bg) return { backgroundColor: '#FFFFFF' };
+  if (bg.startsWith('linear-gradient')) return { background: bg };
+  if (bg.includes('gradient')) return { backgroundColor: '#FFFFFF' };
+  return { backgroundColor: bg };
+}
+
+interface ZapCardProps {
+  items: ZapItem[];
+  position: 'above' | 'below';
+  isOpen: boolean;
+  onZap: (item: ZapItem) => void;
+}
+
+export const ZapCard: React.FC<ZapCardProps> = ({ items, position, isOpen, onZap }) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Keep upper card scrolled to bottom (closest channel to player visible)
+  useEffect(() => {
+    if (position === 'above' && isOpen && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [isOpen, position, items]);
+
+  const borderRadius =
+    position === 'above'
+      ? '12px 12px 0 0'
+      : '0 0 12px 12px';
+
+  return (
+    <Box
+      sx={{
+        maxHeight: isOpen && items.length > 0 ? `${CARD_MAX_HEIGHT}px` : 0,
+        overflow: 'hidden',
+        transition: 'max-height 280ms cubic-bezier(0.4, 0, 0.2, 1)',
+        pointerEvents: isOpen && items.length > 0 ? 'auto' : 'none',
+        bgcolor: CARD_BG,
+        borderRadius,
+      }}
+    >
+      <Box
+        ref={scrollRef}
+        sx={{
+          maxHeight: `${CARD_MAX_HEIGHT}px`,
+          overflowY: 'auto',
+          '&::-webkit-scrollbar': { width: '4px' },
+          '&::-webkit-scrollbar-track': { background: 'transparent' },
+          '&::-webkit-scrollbar-thumb': {
+            background: 'rgba(255,255,255,0.2)',
+            borderRadius: '2px',
+          },
+        }}
+      >
+        {items.map((item) => (
+          <Box
+            key={item.id}
+            onClick={() => onZap(item)}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              height: `${ROW_HEIGHT}px`,
+              px: 1.5,
+              gap: 1.5,
+              cursor: 'pointer',
+              bgcolor: item.isLive ? 'rgba(255,255,255,0.08)' : 'rgba(255,255,255,0.05)',
+              borderRadius: '10px',
+              mx: '6px',
+              my: '2px',
+              borderBottom: '1px solid rgba(255,255,255,0.06)',
+              '&:hover': {
+                bgcolor: 'rgba(255,255,255,0.12)',
+              },
+              transition: 'background-color 150ms ease',
+            }}
+          >
+            {/* Channel logo */}
+            <Box
+              sx={{
+                width: 72,
+                height: 36,
+                borderRadius: '6px',
+                overflow: 'hidden',
+                flexShrink: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                ...getLogoBg(item.backgroundColor),
+              }}
+            >
+              {item.logoUrl && (
+                <Box
+                  component="img"
+                  src={item.logoUrl}
+                  alt={item.name}
+                  sx={{
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'contain',
+                  }}
+                />
+              )}
+            </Box>
+
+            {/* Channel name + program */}
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                sx={{
+                  color: '#e2e8f0',
+                  fontSize: '14px',
+                  fontWeight: 600,
+                  lineHeight: 1.3,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {item.name}
+              </Typography>
+              {item.programName && (
+                <Typography
+                  sx={{
+                    color: '#64748b',
+                    fontSize: '11px',
+                    lineHeight: 1.3,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {item.programName}
+                </Typography>
+              )}
+            </Box>
+
+            {/* Live badge */}
+            {item.isLive && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.5,
+                  flexShrink: 0,
+                }}
+              >
+                <Box
+                  sx={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: '50%',
+                    bgcolor: '#F44336',
+                  }}
+                />
+                <Typography
+                  sx={{
+                    color: '#F44336',
+                    fontSize: '10px',
+                    fontWeight: 800,
+                    letterSpacing: '0.05em',
+                  }}
+                >
+                  EN VIVO
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/ZapSidePanel.tsx
+++ b/src/components/ZapSidePanel.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { Box, Typography } from '@mui/material';
+import type { ZapItem } from '@/types/zap';
+
+const PANEL_WIDTH = 200;
+const ROW_HEIGHT = 76;
+const PANEL_BG = '#1E293B';
+
+function getLogoBg(bg?: string | null): React.CSSProperties {
+  if (!bg) return { backgroundColor: '#FFFFFF' };
+  if (bg.startsWith('linear-gradient')) return { background: bg };
+  if (bg.includes('gradient')) return { backgroundColor: '#FFFFFF' };
+  return { backgroundColor: bg };
+}
+
+interface ZapSidePanelProps {
+  items: ZapItem[];            // All channels in grid order (videoUrl !== null + current)
+  currentId: number | undefined;
+  isOpen: boolean;
+  playerHeight: number;
+  onZap: (item: ZapItem) => void;
+}
+
+export const ZapSidePanel: React.FC<ZapSidePanelProps> = ({
+  items,
+  currentId,
+  isOpen,
+  onZap,
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const currentRowRef = useRef<HTMLDivElement>(null);
+
+  // When opened, scroll so the current channel is centered in the panel
+  useEffect(() => {
+    if (isOpen && currentRowRef.current) {
+      currentRowRef.current.scrollIntoView({ block: 'center', behavior: 'instant' });
+    }
+  }, [isOpen]);
+
+  return (
+    <Box
+      sx={{ width: '100%', height: '100%' }}
+      onWheel={(e) => e.stopPropagation()}
+      onTouchMove={(e) => e.stopPropagation()}
+    >
+      <Box
+        ref={scrollRef}
+        sx={{
+          width: `${PANEL_WIDTH}px`,
+          height: '100%',
+          bgcolor: PANEL_BG,
+          borderRadius: '12px 0 0 12px',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          overscrollBehavior: 'contain',
+          display: 'flex',
+          flexDirection: 'column',
+          pt: 0.5,
+          pb: 0.5,
+          '&::-webkit-scrollbar': { width: '3px' },
+          '&::-webkit-scrollbar-track': { background: 'transparent' },
+          '&::-webkit-scrollbar-thumb': {
+            background: 'rgba(255,255,255,0.15)',
+            borderRadius: '2px',
+          },
+        }}
+      >
+        {items.map((item) => {
+          const isCurrent = item.id === currentId;
+          return (
+            <ChannelRow
+              key={item.id}
+              item={item}
+              isCurrent={isCurrent}
+              currentRef={isCurrent ? currentRowRef : undefined}
+              onZap={onZap}
+            />
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+function ChannelRow({
+  item,
+  isCurrent,
+  currentRef,
+  onZap,
+}: {
+  item: ZapItem;
+  isCurrent: boolean;
+  currentRef?: React.RefObject<HTMLDivElement | null>;
+  onZap: (item: ZapItem) => void;
+}) {
+  return (
+    <Box
+      ref={currentRef}
+      onClick={() => !isCurrent && onZap(item)}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        height: `${ROW_HEIGHT}px`,
+        px: 1,
+        gap: 1,
+        cursor: isCurrent ? 'default' : 'pointer',
+        bgcolor: isCurrent
+          ? 'rgba(59,130,246,0.18)'
+          : item.isLive
+            ? 'rgba(255,255,255,0.08)'
+            : 'rgba(255,255,255,0.04)',
+        mx: '4px',
+        my: '2px',
+        borderRadius: '8px',
+        border: isCurrent ? '1px solid rgba(59,130,246,0.45)' : '1px solid transparent',
+        '&:hover': {
+          bgcolor: isCurrent ? 'rgba(59,130,246,0.18)' : 'rgba(255,255,255,0.13)',
+        },
+        transition: 'background-color 150ms ease',
+      }}
+    >
+      {/* Logo */}
+      <Box
+        sx={{
+          width: 60,
+          height: 32,
+          borderRadius: '6px',
+          overflow: 'hidden',
+          flexShrink: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          ...getLogoBg(item.backgroundColor),
+        }}
+      >
+        {item.logoUrl && (
+          <Box
+            component="img"
+            src={item.logoUrl}
+            alt={item.name}
+            sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
+          />
+        )}
+      </Box>
+
+      {/* Text */}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {/* Always red live dot — current channel is always live */}
+          {(isCurrent || item.isLive) && (
+            <Box
+              sx={{
+                width: 5,
+                height: 5,
+                borderRadius: '50%',
+                bgcolor: '#F44336',
+                flexShrink: 0,
+              }}
+            />
+          )}
+          <Typography
+            sx={{
+              color: isCurrent ? '#93c5fd' : '#e2e8f0',
+              fontSize: '13px',
+              fontWeight: isCurrent ? 700 : 600,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {item.name}
+          </Typography>
+        </Box>
+        {item.programName && (
+          <Typography
+            sx={{
+              color: '#64748b',
+              fontSize: '11px',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              lineHeight: 1.3,
+            }}
+          >
+            {item.programName}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/contexts/YouTubeGlobalPlayerContext.tsx
+++ b/src/contexts/YouTubeGlobalPlayerContext.tsx
@@ -3,21 +3,34 @@
 import React, { createContext, useContext, useState } from 'react';
 import { event as gaEvent } from '@/lib/gtag';
 import Clarity from '@microsoft/clarity';
+import type { ZapItem } from '@/types/zap';
+import { parseStreamUrl } from '@/utils/parseStreamUrl';
 
 export type StreamingService = 'youtube' | 'twitch' | 'kick';
 
+export interface ChannelInfo {
+  channelId: number;
+  channelName: string;
+  channelLogo?: string | null;
+  channelBackgroundColor?: string | null;
+}
+
 interface StreamingPlayerData {
   service: StreamingService;
-  embedPath: string; // For YouTube: videoId or "videoseries?list=PLAYLIST_ID", For Twitch/Kick: channel name
+  embedPath: string;
+  channelInfo?: ChannelInfo;
 }
 
 interface YouTubeGlobalPlayerContextType {
   playerData: StreamingPlayerData | null;
   open: boolean;
   minimized: boolean;
-  openVideo: (videoId: string) => void;
-  openPlaylist: (listId: string) => void;
-  openStream: (service: StreamingService, channelName: string) => void;
+  zapList: ZapItem[];
+  setZapList: (list: ZapItem[]) => void;
+  openVideo: (videoId: string, channelInfo?: ChannelInfo) => void;
+  openPlaylist: (listId: string, channelInfo?: ChannelInfo) => void;
+  openStream: (service: StreamingService, channelName: string, channelInfo?: ChannelInfo) => void;
+  zapToChannel: (item: ZapItem) => void;
   closePlayer: () => void;
   minimizePlayer: () => void;
   maximizePlayer: () => void;
@@ -29,24 +42,39 @@ export const YouTubePlayerProvider: React.FC<{ children: React.ReactNode }> = ({
   const [playerData, setPlayerData] = useState<StreamingPlayerData | null>(null);
   const [open, setOpen] = useState(false);
   const [minimized, setMinimized] = useState(false);
+  const [zapList, setZapList] = useState<ZapItem[]>([]);
 
-  const openVideo = (id: string) => {
-    setPlayerData({ service: 'youtube', embedPath: id });
+  const openVideo = (id: string, channelInfo?: ChannelInfo) => {
+    setPlayerData({ service: 'youtube', embedPath: id, channelInfo });
     setOpen(true);
     setMinimized(false);
   };
 
-  const openPlaylist = (listId: string) => {
-    // "videoseries?list=" es exactamente lo que usaba /embed/videoseries?list=...
-    setPlayerData({ service: 'youtube', embedPath: `videoseries?list=${listId}` });
+  const openPlaylist = (listId: string, channelInfo?: ChannelInfo) => {
+    setPlayerData({ service: 'youtube', embedPath: `videoseries?list=${listId}`, channelInfo });
     setOpen(true);
     setMinimized(false);
   };
 
-  const openStream = (service: StreamingService, channelName: string) => {
-    setPlayerData({ service, embedPath: channelName });
+  const openStream = (service: StreamingService, channelName: string, channelInfo?: ChannelInfo) => {
+    setPlayerData({ service, embedPath: channelName, channelInfo });
     setOpen(true);
     setMinimized(false);
+  };
+
+  const zapToChannel = (item: ZapItem) => {
+    if (!item.videoUrl) return;
+    const parsed = parseStreamUrl(item.videoUrl);
+    if (!parsed) return;
+
+    const channelInfo: ChannelInfo = {
+      channelId: item.id,
+      channelName: item.name,
+      channelLogo: item.logoUrl,
+      channelBackgroundColor: item.backgroundColor,
+    };
+
+    setPlayerData({ service: parsed.service, embedPath: parsed.embedPath, channelInfo });
   };
 
   const closePlayer = () => {
@@ -57,20 +85,14 @@ export const YouTubePlayerProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const minimizePlayer = () => {
     setMinimized(true);
-    try { Clarity.event('minimize_youtube') } catch { /* Clarity not yet loaded */ }
-    gaEvent({
-      action: 'minimize_youtube',
-      params: {}
-    });
+    try { Clarity.event('minimize_youtube'); } catch { /* Clarity not yet loaded */ }
+    gaEvent({ action: 'minimize_youtube', params: {} });
   };
 
   const maximizePlayer = () => {
     setMinimized(false);
-    try { Clarity.event('maximize_youtube') } catch { /* Clarity not yet loaded */ }
-    gaEvent({
-      action: 'maximize_youtube',
-      params: {}
-    });
+    try { Clarity.event('maximize_youtube'); } catch { /* Clarity not yet loaded */ }
+    gaEvent({ action: 'maximize_youtube', params: {} });
   };
 
   return (
@@ -79,9 +101,12 @@ export const YouTubePlayerProvider: React.FC<{ children: React.ReactNode }> = ({
         playerData,
         open,
         minimized,
+        zapList,
+        setZapList,
         openVideo,
         openPlaylist,
         openStream,
+        zapToChannel,
         closePlayer,
         minimizePlayer,
         maximizePlayer,

--- a/src/types/zap.ts
+++ b/src/types/zap.ts
@@ -1,0 +1,10 @@
+export interface ZapItem {
+  id: number;
+  name: string;
+  logoUrl?: string | null;
+  backgroundColor?: string | null;
+  videoUrl: string | null;
+  service: 'youtube' | 'twitch' | 'kick' | null;
+  isLive: boolean;
+  programName?: string | null;
+}

--- a/src/utils/parseStreamUrl.ts
+++ b/src/utils/parseStreamUrl.ts
@@ -1,0 +1,32 @@
+import { extractVideoId } from './extractVideoId';
+import { extractTwitchChannel, extractKickChannel } from './extractStreamChannel';
+
+export type ParsedStreamService = 'youtube' | 'twitch' | 'kick';
+
+export interface ParsedStreamUrl {
+  service: ParsedStreamService;
+  embedPath: string;
+}
+
+export function parseStreamUrl(url: string): ParsedStreamUrl | null {
+  if (!url) return null;
+
+  const twitchChannel = extractTwitchChannel(url);
+  if (twitchChannel) return { service: 'twitch', embedPath: twitchChannel };
+
+  const kickChannel = extractKickChannel(url);
+  if (kickChannel) return { service: 'kick', embedPath: kickChannel };
+
+  try {
+    const urlObj = new URL(url);
+    const listId = urlObj.searchParams.get('list');
+    if (listId) return { service: 'youtube', embedPath: `videoseries?list=${listId}` };
+  } catch {
+    // invalid URL
+  }
+
+  const videoId = extractVideoId(url);
+  if (videoId) return { service: 'youtube', embedPath: videoId };
+
+  return null;
+}


### PR DESCRIPTION
## [1.23.0] - 2026-06-18

### Added
- **Zapping between channels in the video player**: when the player is open and maximized, a toggle button (≡) reveals a side panel (desktop) or cards above/below (mobile) listing all currently-live channels. Clicking any channel zaps to it without closing the player.
  - Desktop: `ZapSidePanel` — fixed-position sidebar to the left of the player (200 px wide, slides in/out with a 280 ms transition). Shows all live channels in grid order; the currently-playing channel is highlighted with a blue border and bold text. Auto-scrolls to center the current channel on open.
  - Mobile: `ZapCard` — collapsible cards above/below the player showing up to 2 live channels from each direction. Animated with `max-height` transition.
  - New `ZapItem` type (`src/types/zap.ts`) and `parseStreamUrl` utility (`src/utils/parseStreamUrl.ts`) to detect YouTube / Twitch / Kick URLs.
  - `YouTubeGlobalPlayerContext` extended with `zapList`, `setZapList`, and `zapToChannel`.
  - `HomeClient` derives the zap list from `channelsWithSchedules` + `liveStatus` (live channels only; current channel always included).
  - Channel mini-logo and name shown in the player controls bar.

### Fixed
- Overflow zone: programs with `start_time = "00:00"` on the next day are no longer injected into the current day's overflow zone. They appeared flush against the right edge of cross-midnight blocks (which end at 24:00), creating a visual duplicate. These programs now only appear when viewing their own day. (`ScheduleGridDesktop`, `ScheduleGridMobile`)
- Overflow zone: added `positionOffset` to the React `Fragment` key in `ScheduleRow` (`scheduleId|programId|positionOffset`). The same schedule could appear as an overflow block (positionOffset=1440) on day X and as a current-day block (positionOffset=0) on day X+1 — React reused the component instance, causing the previous day's block color to persist via the `background-color` CSS transition.
- Double tooltip on same-program multiple slots: `tooltipId` in `ProgramBlock` was keyed by `program.id`, shared across all schedule entries for the same program. Hovering either slot opened both tooltips simultaneously. Fixed by including `start_time` in the ID (`program-${id}-${start}`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)