### PR TITLE
Release 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 
+## [1.24.0] - 2026-06-18
+
+### Fixed
+- Zapping panel on `/streamers` page was showing channels instead of streamers. `StreamersClient` now registers a live-streamers-only zap list (cleared on unmount), while `HomeClient` clears its channel list on unmount, so each page owns the zap list while active.
+- Zapping panel and mobile cards now render streamer logos as square (44×44 / 48×48 with `objectFit: cover` and dark fallback background) instead of the rectangular channel logo dimensions.
+- Player header mini-logo is now square (28×28) when showing a streamer, matching the zap panel style.
+- `handleServiceClick` in `StreamersClient` now passes `channelInfo` (streamer id/name/logo) to `openStream`/`openVideo`, so the player header and current-item highlighting work correctly when opening from the streamers page.
+
+---
+
 ## [1.23.1] - 2026-06-18
 
 ### Fixed

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -251,6 +251,7 @@ export default function HomeClient({ initialData }: HomeClientProps) {
 
   useEffect(() => {
     setZapList(zapList);
+    return () => setZapList([]);
   }, [zapList, setZapList]);
 
   useEffect(() => {

--- a/src/components/StreamersClient.tsx
+++ b/src/components/StreamersClient.tsx
@@ -33,9 +33,11 @@ import { Streamer, StreamingService } from '@/types/streamer';
 import { Category } from '@/types/channel';
 import { useStreamersConfig } from '@/hooks/useStreamersConfig';
 import { getColorForChannel } from '@/utils/colors';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { extractTwitchChannel, extractKickChannel } from '@/utils/extractStreamChannel';
 import { extractVideoId } from '@/utils/extractVideoId';
+import type { ZapItem } from '@/types/zap';
+import type { ChannelInfo } from '@/contexts/YouTubeGlobalPlayerContext';
 
 const MotionBox = motion(Box);
 const MotionCard = motion(Card);
@@ -95,7 +97,7 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
   // Use prop if provided, otherwise fall back to hook for backward compatibility
   const streamersConfigHook = useStreamersConfig();
   const finalStreamersEnabled = streamersEnabled ?? streamersConfigHook.streamersEnabled;
-  const { openVideo, openStream } = useYouTubePlayer();
+  const { openVideo, openStream, setZapList } = useYouTubePlayer();
   const [streamers, setStreamers] = useState<Streamer[]>(initialStreamers || []);
   // Only show loading if we have no initial data at all (undefined/null, not empty array)
   const [loading, setLoading] = useState(!initialStreamers);
@@ -163,6 +165,40 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
       console.error('Error fetching subscriptions:', err);
     }
   };
+
+  // Build zap list from live streamers and push it into the global player context.
+  // Cleared on unmount so the channels page can restore its own list.
+  const streamerZapList = useMemo<ZapItem[]>(() => {
+    return streamers
+      .filter(s => s.is_live)
+      .map(s => {
+        // Pick the first active service URL
+        const activeServiceName = s.active_services?.[0];
+        const activeService = activeServiceName
+          ? s.services.find(sv => sv.service === activeServiceName)
+          : s.services[0];
+        const videoUrl = activeService?.url ?? null;
+        const service = activeService
+          ? (activeService.service.toLowerCase() as 'youtube' | 'twitch' | 'kick')
+          : null;
+        return {
+          id: s.id,
+          name: s.name,
+          logoUrl: s.logo_url,
+          backgroundColor: null,
+          videoUrl,
+          service,
+          isLive: true,
+          programName: null,
+          logoShape: 'square' as const,
+        };
+      });
+  }, [streamers]);
+
+  useEffect(() => {
+    setZapList(streamerZapList);
+    return () => setZapList([]);
+  }, [streamerZapList, setZapList]);
 
   useEffect(() => {
     // Only fetch if we truly have no initial data (undefined/null) AND haven't fetched yet
@@ -261,7 +297,7 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
         category: 'streamer',
         streamer_name: streamer.name,
         streamer_id: streamer.id,
-        platform: service, // 'twitch', 'kick', 'youtube'
+        platform: service,
       },
       userData: typedSession?.user
     });
@@ -278,25 +314,28 @@ export default function StreamersClient({ initialStreamers, initialCategories = 
       }
     }
 
+    const channelInfo: ChannelInfo = {
+      channelId: streamer.id,
+      channelName: streamer.name,
+      channelLogo: streamer.logo_url,
+      channelBackgroundColor: null,
+      logoShape: 'square',
+    };
+
     if (service === StreamingService.YOUTUBE) {
-      // For YouTube, extract video ID and use openVideo
-      // Note: YouTube only supports embedding videos, not channel pages
       const videoId = extractVideoId(url);
       if (videoId && !videoId.startsWith('http') && !videoId.includes('@')) {
-        // It's a valid video ID - use it
-        openVideo(videoId);
+        openVideo(videoId, channelInfo);
       }
-      // If it's a channel URL, we can't embed it directly
-      // The URL should be a video URL for embedding to work
     } else if (service === StreamingService.TWITCH) {
       const channelName = extractTwitchChannel(url);
       if (channelName) {
-        openStream('twitch', channelName);
+        openStream('twitch', channelName, channelInfo);
       }
     } else if (service === StreamingService.KICK) {
       const channelName = extractKickChannel(url);
       if (channelName) {
-        openStream('kick', channelName);
+        openStream('kick', channelName, channelInfo);
       }
     }
   };

--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -317,31 +317,38 @@ export const YouTubeGlobalPlayer = () => {
               </IconButton>
             )}
 
-            {/* Channel mini-logo + name */}
+            {/* Channel / streamer mini-logo + name */}
             {!minimized && channelInfo && (
               <>
-                <Box
-                  sx={{
-                    width: 44,
-                    height: 22,
-                    borderRadius: '4px',
-                    overflow: 'hidden',
-                    flexShrink: 0,
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    ...getLogoBg(channelInfo.channelBackgroundColor),
-                  }}
-                >
-                  {channelInfo.channelLogo && (
+                {(() => {
+                  const isSquare = channelInfo.logoShape === 'square';
+                  return (
                     <Box
-                      component="img"
-                      src={channelInfo.channelLogo}
-                      alt={channelInfo.channelName}
-                      sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
-                    />
-                  )}
-                </Box>
+                      sx={{
+                        width: isSquare ? 28 : 44,
+                        height: 28,
+                        borderRadius: isSquare ? '6px' : '4px',
+                        overflow: 'hidden',
+                        flexShrink: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        ...(isSquare
+                          ? { backgroundColor: '#1e293b' }
+                          : getLogoBg(channelInfo.channelBackgroundColor)),
+                      }}
+                    >
+                      {channelInfo.channelLogo && (
+                        <Box
+                          component="img"
+                          src={channelInfo.channelLogo}
+                          alt={channelInfo.channelName}
+                          sx={{ width: '100%', height: '100%', objectFit: isSquare ? 'cover' : 'contain' }}
+                        />
+                      )}
+                    </Box>
+                  );
+                })()}
                 <Typography
                   sx={{
                     color: '#e2e8f0',

--- a/src/components/ZapCard.tsx
+++ b/src/components/ZapCard.tsx
@@ -9,10 +9,10 @@ const MAX_VISIBLE_ROWS = 2;
 const CARD_MAX_HEIGHT = ROW_HEIGHT * MAX_VISIBLE_ROWS;
 const CARD_BG = '#1E293B';
 
-function getLogoBg(bg?: string | null): React.CSSProperties {
-  if (!bg) return { backgroundColor: '#FFFFFF' };
+function getLogoBg(bg?: string | null, square?: boolean): React.CSSProperties {
+  if (!bg) return { backgroundColor: square ? '#1e293b' : '#FFFFFF' };
   if (bg.startsWith('linear-gradient')) return { background: bg };
-  if (bg.includes('gradient')) return { backgroundColor: '#FFFFFF' };
+  if (bg.includes('gradient')) return { backgroundColor: square ? '#1e293b' : '#FFFFFF' };
   return { backgroundColor: bg };
 }
 
@@ -84,33 +84,38 @@ export const ZapCard: React.FC<ZapCardProps> = ({ items, position, isOpen, onZap
               transition: 'background-color 150ms ease',
             }}
           >
-            {/* Channel logo */}
-            <Box
-              sx={{
-                width: 72,
-                height: 36,
-                borderRadius: '6px',
-                overflow: 'hidden',
-                flexShrink: 0,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                ...getLogoBg(item.backgroundColor),
-              }}
-            >
-              {item.logoUrl && (
+            {/* Logo */}
+            {(() => {
+              const isSquare = item.logoShape === 'square';
+              return (
                 <Box
-                  component="img"
-                  src={item.logoUrl}
-                  alt={item.name}
                   sx={{
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'contain',
+                    width: isSquare ? 48 : 72,
+                    height: isSquare ? 48 : 36,
+                    borderRadius: isSquare ? '8px' : '6px',
+                    overflow: 'hidden',
+                    flexShrink: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    ...getLogoBg(item.backgroundColor, isSquare),
                   }}
-                />
-              )}
-            </Box>
+                >
+                  {item.logoUrl && (
+                    <Box
+                      component="img"
+                      src={item.logoUrl}
+                      alt={item.name}
+                      sx={{
+                        width: '100%',
+                        height: '100%',
+                        objectFit: isSquare ? 'cover' : 'contain',
+                      }}
+                    />
+                  )}
+                </Box>
+              );
+            })()}
 
             {/* Channel name + program */}
             <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/src/components/ZapSidePanel.tsx
+++ b/src/components/ZapSidePanel.tsx
@@ -8,10 +8,10 @@ const PANEL_WIDTH = 200;
 const ROW_HEIGHT = 76;
 const PANEL_BG = '#1E293B';
 
-function getLogoBg(bg?: string | null): React.CSSProperties {
-  if (!bg) return { backgroundColor: '#FFFFFF' };
+function getLogoBg(bg?: string | null, square?: boolean): React.CSSProperties {
+  if (!bg) return { backgroundColor: square ? '#1e293b' : '#FFFFFF' };
   if (bg.startsWith('linear-gradient')) return { background: bg };
-  if (bg.includes('gradient')) return { backgroundColor: '#FFFFFF' };
+  if (bg.includes('gradient')) return { backgroundColor: square ? '#1e293b' : '#FFFFFF' };
   return { backgroundColor: bg };
 }
 
@@ -122,28 +122,33 @@ function ChannelRow({
       }}
     >
       {/* Logo */}
-      <Box
-        sx={{
-          width: 60,
-          height: 32,
-          borderRadius: '6px',
-          overflow: 'hidden',
-          flexShrink: 0,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          ...getLogoBg(item.backgroundColor),
-        }}
-      >
-        {item.logoUrl && (
+      {(() => {
+        const isSquare = item.logoShape === 'square';
+        return (
           <Box
-            component="img"
-            src={item.logoUrl}
-            alt={item.name}
-            sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
-          />
-        )}
-      </Box>
+            sx={{
+              width: isSquare ? 44 : 60,
+              height: isSquare ? 44 : 32,
+              borderRadius: isSquare ? '8px' : '6px',
+              overflow: 'hidden',
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              ...getLogoBg(item.backgroundColor, isSquare),
+            }}
+          >
+            {item.logoUrl && (
+              <Box
+                component="img"
+                src={item.logoUrl}
+                alt={item.name}
+                sx={{ width: '100%', height: '100%', objectFit: isSquare ? 'cover' : 'contain' }}
+              />
+            )}
+          </Box>
+        );
+      })()}
 
       {/* Text */}
       <Box sx={{ flex: 1, minWidth: 0 }}>

--- a/src/contexts/YouTubeGlobalPlayerContext.tsx
+++ b/src/contexts/YouTubeGlobalPlayerContext.tsx
@@ -13,6 +13,7 @@ export interface ChannelInfo {
   channelName: string;
   channelLogo?: string | null;
   channelBackgroundColor?: string | null;
+  logoShape?: 'rect' | 'square';
 }
 
 interface StreamingPlayerData {
@@ -72,6 +73,7 @@ export const YouTubePlayerProvider: React.FC<{ children: React.ReactNode }> = ({
       channelName: item.name,
       channelLogo: item.logoUrl,
       channelBackgroundColor: item.backgroundColor,
+      logoShape: item.logoShape,
     };
 
     setPlayerData({ service: parsed.service, embedPath: parsed.embedPath, channelInfo });

--- a/src/types/zap.ts
+++ b/src/types/zap.ts
@@ -7,4 +7,5 @@ export interface ZapItem {
   service: 'youtube' | 'twitch' | 'kick' | null;
   isLive: boolean;
   programName?: string | null;
+  logoShape?: 'rect' | 'square';
 }


### PR DESCRIPTION
## [1.24.0] - 2026-06-18

### Fixed
- Zapping panel on `/streamers` page was showing channels instead of streamers. `StreamersClient` now registers a live-streamers-only zap list (cleared on unmount), while `HomeClient` clears its channel list on unmount, so each page owns the zap list while active.
- Zapping panel and mobile cards now render streamer logos as square (44×44 / 48×48 with `objectFit: cover` and dark fallback background) instead of the rectangular channel logo dimensions.
- Player header mini-logo is now square (28×28) when showing a streamer, matching the zap panel style.
- `handleServiceClick` in `StreamersClient` now passes `channelInfo` (streamer id/name/logo) to `openStream`/`openVideo`, so the player header and current-item highlighting work correctly when opening from the streamers page.
- New `logoShape?: 'rect' | 'square'` field on `ZapItem` and `ChannelInfo`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)