### PR TITLE
🎨 Palette: [Add tooltips to close IconButtons]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2024-06-19 - Added Tooltips to close IconButtons
+**Learning:** While `aria-label` provides accessibility for screen readers on icon-only buttons like `<IconButton>`, sighted users also benefit from tooltips to understand the action, especially on standard icons like "Close" within dialogs or modals.
+**Action:** When adding or updating `<IconButton>` components, ensure they are wrapped in a `<Tooltip>` with a descriptive title in Spanish, in addition to having an `aria-label`.

--- a/src/components/CookiePreferencesModal.tsx
+++ b/src/components/CookiePreferencesModal.tsx
@@ -17,6 +17,7 @@ import {
   AccordionDetails,
   useTheme,
   useMediaQuery,
+  Tooltip,
 } from '@mui/material';
 import { 
   Close as CloseIcon, 
@@ -141,9 +142,11 @@ export function CookiePreferencesModal() {
           <Typography variant="h6" component="h2" sx={{ color: mode === 'light' ? '#000000' : '#ffffff' }}>
             🍪 Configuración de Cookies
           </Typography>
-          <IconButton aria-label="Cerrar preferencias de cookies" onClick={closePreferences} size="small" sx={{ color: mode === 'light' ? '#000000' : '#ffffff' }}>
-            <CloseIcon />
-          </IconButton>
+          <Tooltip title="Cerrar preferencias de cookies">
+            <IconButton aria-label="Cerrar preferencias de cookies" onClick={closePreferences} size="small" sx={{ color: mode === 'light' ? '#000000' : '#ffffff' }}>
+              <CloseIcon />
+            </IconButton>
+          </Tooltip>
         </Box>
       </DialogTitle>
 

--- a/src/components/HolidayDialog.tsx
+++ b/src/components/HolidayDialog.tsx
@@ -5,6 +5,7 @@ import {
   IconButton,
   useTheme,
   Typography,
+  Tooltip,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 
@@ -38,20 +39,22 @@ const HolidayDialog: React.FC<Props> = ({ open, onClose }) => {
         sx: { backgroundColor: 'rgba(0,0,0,0.4)' },
       }}
     >
-      <IconButton
-        onClick={onClose}
-        size="small"
-        aria-label="Cerrar"
-        sx={{
-          position: 'absolute',
-          top: 1,
-          right: 1,
-          color: theme.palette.text.secondary,
-          '&:hover': { color: theme.palette.text.primary },
-        }}
-      >
-        <CloseIcon fontSize="small" />
-      </IconButton>
+      <Tooltip title="Cerrar">
+        <IconButton
+          onClick={onClose}
+          size="small"
+          aria-label="Cerrar"
+          sx={{
+            position: 'absolute',
+            top: 1,
+            right: 1,
+            color: theme.palette.text.secondary,
+            '&:hover': { color: theme.palette.text.primary },
+          }}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
 
       <DialogContent sx={{ p: 0, pt: { xs: 1, sm: 1 } }}>
         <Typography

--- a/src/components/SeasonalDialog.tsx
+++ b/src/components/SeasonalDialog.tsx
@@ -5,6 +5,7 @@ import {
   IconButton,
   useTheme,
   Typography,
+  Tooltip,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
 
@@ -38,20 +39,22 @@ const SeasonalDialog: React.FC<Props> = ({ open, onClose }) => {
         sx: { backgroundColor: 'rgba(0,0,0,0.4)' },
       }}
     >
-      <IconButton
-        onClick={onClose}
-        size="small"
-        aria-label="Cerrar"
-        sx={{
-          position: 'absolute',
-          top: 1,
-          right: 1,
-          color: theme.palette.text.secondary,
-          '&:hover': { color: theme.palette.text.primary },
-        }}
-      >
-        <CloseIcon fontSize="small" />
-      </IconButton>
+      <Tooltip title="Cerrar">
+        <IconButton
+          onClick={onClose}
+          size="small"
+          aria-label="Cerrar"
+          sx={{
+            position: 'absolute',
+            top: 1,
+            right: 1,
+            color: theme.palette.text.secondary,
+            '&:hover': { color: theme.palette.text.primary },
+          }}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
 
       <DialogContent sx={{ p: 0, pt: { xs: 1, sm: 1 } }}>
         <Typography

--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   Dialog, DialogTitle, DialogContent,
-  IconButton, Box, useTheme, Stepper, Step, StepLabel, StepConnector, stepConnectorClasses, StepIconProps, Button
+  IconButton, Box, useTheme, Stepper, Step, StepLabel, StepConnector, stepConnectorClasses, StepIconProps, Button, Tooltip
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
@@ -280,7 +280,9 @@ export default function LoginModal({ open, onClose }: { open: boolean; onClose: 
                     ? (forgotPassword ? 'Nueva contraseña' : 'Creá tu contraseña')
                     : ''
         )}
-        <IconButton aria-label="Cerrar modal" onClick={socialLoginPending ? undefined : onClose}><CloseIcon /></IconButton>
+        <Tooltip title="Cerrar modal">
+          <IconButton aria-label="Cerrar modal" onClick={socialLoginPending ? undefined : onClose}><CloseIcon /></IconButton>
+        </Tooltip>
       </DialogTitle>
 
       {(


### PR DESCRIPTION
💡 **What:** Added `<Tooltip>` wrappers to icon-only close buttons (`<IconButton>`) in several modal and dialog components (`SeasonalDialog`, `HolidayDialog`, `CookiePreferencesModal`, `LoginModal`).
🎯 **Why:** While screen readers benefit from `aria-label` attributes, sighted users often rely on visual tooltips on hover to confirm the specific action of icon-only buttons, making the interface more intuitive and accessible.
♿ **Accessibility:** Improves clarity for sighted users navigating dialogs by providing immediate text feedback ("Cerrar", "Cerrar modal", etc.) when hovering over the close icon.

---
*PR created automatically by Jules for task [14135154698398788528](https://jules.google.com/task/14135154698398788528) started by @matiasrozenblum*