### PR TITLE
🎨 Palette: Add tooltips to backoffice table buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2024-06-20 - Adding Tooltips to IconButtons
+**Learning:** Icon-only buttons (like pagination controls and action icons in tables) often lack immediate visual context for sighted users, and if disabled without a `span` wrapper, their tooltips won't fire in Material-UI.
+**Action:** Always wrap `IconButton` components in `<Tooltip>` for better UX. If the button can enter a `disabled` state (e.g. pagination bounds), ensure the `<IconButton>` is wrapped inside a generic HTML tag like `<span>` so that the Tooltip still triggers and explains the disabled state if needed.

--- a/src/components/backoffice/UsersTable.tsx
+++ b/src/components/backoffice/UsersTable.tsx
@@ -27,6 +27,7 @@ import {
   InputLabel,
   Pagination,
   SelectChangeEvent,
+  Tooltip,
 } from '@mui/material';
 import { Edit, Delete, Add, NavigateBefore, NavigateNext } from '@mui/icons-material';
 import { User } from '@/types/user';
@@ -357,25 +358,33 @@ export function UsersTable() {
           
           {/* Page Navigation */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <IconButton
-              aria-label="Página anterior"
-              onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage - 1)}
-              disabled={currentPage <= 1}
-              size="small"
-            >
-              <NavigateBefore />
-            </IconButton>
+            <Tooltip title="Página anterior" arrow placement="top">
+              <span>
+                <IconButton
+                  aria-label="Página anterior"
+                  onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage - 1)}
+                  disabled={currentPage <= 1}
+                  size="small"
+                >
+                  <NavigateBefore />
+                </IconButton>
+              </span>
+            </Tooltip>
             <Typography variant="body2" color="text.primary">
               Página {currentPage} de {totalPages}
             </Typography>
-            <IconButton
-              aria-label="Página siguiente"
-              onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage + 1)}
-              disabled={currentPage >= totalPages}
-              size="small"
-            >
-              <NavigateNext />
-            </IconButton>
+            <Tooltip title="Página siguiente" arrow placement="top">
+              <span>
+                <IconButton
+                  aria-label="Página siguiente"
+                  onClick={() => handlePageChange({} as React.ChangeEvent<unknown>, currentPage + 1)}
+                  disabled={currentPage >= totalPages}
+                  size="small"
+                >
+                  <NavigateNext />
+                </IconButton>
+              </span>
+            </Tooltip>
           </Box>
           
           <Button variant="contained" startIcon={<Add />} onClick={() => handleOpenDialog()}>
@@ -426,12 +435,16 @@ export function UsersTable() {
                 </TableCell>
                 <TableCell>
                   <Box sx={{ display: 'flex', gap: 0.5 }}>
-                    <IconButton aria-label="Editar usuario" size="small" onClick={() => handleOpenDialog(user)}>
-                      <Edit />
-                    </IconButton>
-                    <IconButton aria-label="Eliminar usuario" size="small" onClick={() => handleDelete(user.id)}>
-                      <Delete />
-                    </IconButton>
+                    <Tooltip title="Editar usuario" arrow>
+                      <IconButton aria-label="Editar usuario" size="small" onClick={() => handleOpenDialog(user)}>
+                        <Edit />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Eliminar usuario" arrow>
+                      <IconButton aria-label="Eliminar usuario" size="small" onClick={() => handleDelete(user.id)}>
+                        <Delete />
+                      </IconButton>
+                    </Tooltip>
                   </Box>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
💡 What: Added Material-UI Tooltips to the icon-only buttons in the backoffice UsersTable (pagination controls, edit, and delete buttons).
🎯 Why: Icon-only buttons lack immediate visual context for sighted users. This change improves usability by explaining the button's function on hover.
♿ Accessibility: The tooltips provide visual labels that complement the existing ARIA labels. Crucially, the pagination buttons are wrapped in `<span>` tags so the tooltips still trigger when the buttons are disabled (e.g., at the start or end of the table pages), ensuring users know what the disabled control is for.

---
*PR created automatically by Jules for task [11803169503552938977](https://jules.google.com/task/11803169503552938977) started by @matiasrozenblum*