### PR TITLE
feat: bulk program creation + multi-select delete in backoffice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 
+## [Unreleased]
+
+### Added
+
+- **Creación de programas en múltiples canales**: el selector de canal en el formulario de nuevo programa es ahora un `Autocomplete` multi-select. Con 2+ canales seleccionados se llama a `POST /api/programs/bulk` y se crean N programas independientes en una sola acción.
+- **Creación de programas especiales en múltiples canales**: el selector de canal en el tab "Programas Especiales" también es multi-select; con 2+ canales se llama a `POST /api/weekly-overrides/bulk`.
+- **Borrado masivo de programas**: la columna "Logo" (sin uso) fue reemplazada por una columna de checkbox. Al seleccionar ≥1 programa aparece una barra flotante con la opción de eliminar, con diálogo de confirmación que lista `nombre — canal` de cada programa.
+- **Borrado masivo de cambios semanales**: misma mecánica de checkbox + barra flotante + diálogo de confirmación en los tabs "Semana Actual", "Próxima Semana" y "Programas Especiales". La selección se limpia automáticamente al cambiar de tab.
+
 ## [1.24.0] - 2026-06-18
 
 ### Fixed

--- a/src/app/api/programs/bulk/route.ts
+++ b/src/app/api/programs/bulk/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAccessToken } from '@/utils/auth-server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = await requireAccessToken(request);
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/programs/bulk`;
+    const body = await request.json();
+    const res = await fetch(backendUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/weekly-overrides/bulk/route.ts
+++ b/src/app/api/weekly-overrides/bulk/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAccessToken } from '@/utils/auth-server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = await requireAccessToken(request);
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const body = await request.json();
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/weekly-overrides/bulk`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    const data = await response.json().catch(() => ({}));
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Failed to create bulk weekly overrides',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -30,6 +30,7 @@ import {
   Checkbox,
   Tooltip,
   InputAdornment,
+  Chip,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -72,7 +73,8 @@ export default function ProgramsPage() {
   const [formData, setFormData] = useState({
     name: '',
     description: '',
-    channel_id: '',
+    channel_id: '',       // used when editing an existing program
+    channel_ids: [] as string[], // used when creating (supports multi-select)
     logo_url: '',
     youtube_url: '',
     style_override: '',
@@ -200,6 +202,7 @@ export default function ProgramsPage() {
         name: program.name,
         description: program.description || '',
         channel_id: String(program.channel_id),
+        channel_ids: [],
         logo_url: program.logo_url || '',
         youtube_url: program.youtube_url || '',
         style_override: program.style_override || '',
@@ -212,6 +215,7 @@ export default function ProgramsPage() {
         name: '',
         description: '',
         channel_id: '',
+        channel_ids: [],
         logo_url: '',
         youtube_url: '',
         style_override: '',
@@ -229,6 +233,7 @@ export default function ProgramsPage() {
       name: '',
       description: '',
       channel_id: '',
+      channel_ids: [],
       logo_url: '',
       youtube_url: '',
       style_override: '',
@@ -241,83 +246,136 @@ export default function ProgramsPage() {
 
   const handleSubmit = async () => {
     try {
-      const url = editingProgram
-        ? `/api/programs/${editingProgram.id}`
-        : '/api/programs';
-      const method = editingProgram ? 'PATCH' : 'POST';
-      const res = await fetch(url, {
-        method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ...formData,
-          channel_id: parseInt(formData.channel_id),
-          style_override: formData.style_override || null,
-        }),
-      });
-      const body = await res.json();
-      if (!res.ok) throw new Error(body.details || body.error || 'Error al guardar el programa');
+      if (editingProgram) {
+        // Edit existing program — single channel, same as before
+        const res = await fetch(`/api/programs/${editingProgram.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: formData.name,
+            description: formData.description,
+            channel_id: parseInt(formData.channel_id),
+            logo_url: formData.logo_url,
+            youtube_url: formData.youtube_url,
+            style_override: formData.style_override || null,
+            is_visible: formData.is_visible,
+            is_premiere: formData.is_premiere,
+          }),
+        });
+        const body = await res.json();
+        if (!res.ok) throw new Error(body.details || body.error || 'Error al actualizar el programa');
+        setSuccess('Programa actualizado correctamente');
+      } else if (formData.channel_ids.length > 1) {
+        // Bulk create: multiple channels → single API call, no panelists
+        const scheduleItems = pendingSchedules.map(s => ({
+          startTime: s.startTime,
+          endTime: s.endTime,
+          scheduleType: s.scheduleType || 'weekly',
+          ...(s.dayOfWeek && { dayOfWeek: s.dayOfWeek }),
+          ...(s.weekNumberInMonth && { weekNumberInMonth: parseInt(s.weekNumberInMonth, 10) }),
+          ...(s.specificDate && { specificDate: s.specificDate }),
+        }));
+        const res = await fetch('/api/programs/bulk', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: formData.name,
+            description: formData.description,
+            channel_ids: formData.channel_ids.map(Number),
+            logo_url: formData.logo_url,
+            youtube_url: formData.youtube_url,
+            style_override: formData.style_override || null,
+            is_visible: formData.is_visible,
+            is_premiere: formData.is_premiere,
+            ...(scheduleItems.length > 0 && { schedules: scheduleItems }),
+          }),
+        });
+        const body = await res.json();
+        if (!res.ok) throw new Error(body.details || body.error || 'Error al crear los programas');
+        const scheduleMsg = pendingSchedules.length > 0 ? ` con ${pendingSchedules.length} horario(s)` : '';
+        setSuccess(`${formData.channel_ids.length} programas creados correctamente${scheduleMsg}`);
+      } else {
+        // Single channel create — existing flow
+        const channelId = parseInt(formData.channel_ids[0] ?? formData.channel_id);
+        const res = await fetch('/api/programs', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: formData.name,
+            description: formData.description,
+            channel_id: channelId,
+            logo_url: formData.logo_url,
+            youtube_url: formData.youtube_url,
+            style_override: formData.style_override || null,
+            is_visible: formData.is_visible,
+            is_premiere: formData.is_premiere,
+          }),
+        });
+        const body = await res.json();
+        if (!res.ok) throw new Error(body.details || body.error || 'Error al crear el programa');
 
-      if (!editingProgram && pendingSchedules.length > 0 && typedSession?.accessToken) {
         const newProgramId = body.id;
-        const channelId = parseInt(formData.channel_id);
-        try {
-          const bulkData = {
-            programId: newProgramId.toString(),
-            channelId: channelId.toString(),
-            schedules: pendingSchedules.map(s => ({
-              startTime: s.startTime,
-              endTime: s.endTime,
-              scheduleType: s.scheduleType || 'weekly',
-              ...(s.dayOfWeek && { dayOfWeek: s.dayOfWeek }),
-              ...(s.weekNumberInMonth && { weekNumberInMonth: parseInt(s.weekNumberInMonth, 10) }),
-              ...(s.specificDate && { specificDate: s.specificDate }),
-            })),
-          };
-          const scheduleRes = await fetch('/api/schedules/bulk', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': `Bearer ${typedSession.accessToken}`,
-            },
-            body: JSON.stringify(bulkData),
-          });
-          if (!scheduleRes.ok) {
-            const scheduleBody = await scheduleRes.json().catch(() => ({}));
-            throw new Error(scheduleBody.details || scheduleBody.error || 'Error al crear los horarios');
-          }
-          setSuccess(`Programa creado correctamente con ${pendingSchedules.length} horario(s)`);
-        } catch (scheduleErr) {
-          console.error('Error creating schedules:', scheduleErr);
-          setSuccess('Programa creado correctamente, pero hubo un error al crear algunos horarios');
-        }
-      }
 
-      if (!editingProgram && pendingPanelistIds.length > 0 && typedSession?.accessToken) {
-        const newProgramId = body.id;
-        try {
-          const panelistPromises = pendingPanelistIds.map(panelistId =>
-            fetch(`/api/panelists/${panelistId}/programs/${newProgramId}`, {
+        if (pendingSchedules.length > 0 && typedSession?.accessToken) {
+          try {
+            const bulkData = {
+              programId: newProgramId.toString(),
+              channelId: channelId.toString(),
+              schedules: pendingSchedules.map(s => ({
+                startTime: s.startTime,
+                endTime: s.endTime,
+                scheduleType: s.scheduleType || 'weekly',
+                ...(s.dayOfWeek && { dayOfWeek: s.dayOfWeek }),
+                ...(s.weekNumberInMonth && { weekNumberInMonth: parseInt(s.weekNumberInMonth, 10) }),
+                ...(s.specificDate && { specificDate: s.specificDate }),
+              })),
+            };
+            const scheduleRes = await fetch('/api/schedules/bulk', {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
                 'Authorization': `Bearer ${typedSession.accessToken}`,
               },
-            })
-          );
-          await Promise.all(panelistPromises);
-          const scheduleMsg = pendingSchedules.length > 0 ? ` con ${pendingSchedules.length} horario(s)` : '';
-          setSuccess(`Programa creado correctamente${scheduleMsg} con ${pendingPanelistIds.length} panelista(s)`);
-        } catch (panelistErr) {
-          console.error('Error adding panelists:', panelistErr);
-          const scheduleMsg = pendingSchedules.length > 0 ? ` con ${pendingSchedules.length} horario(s)` : '';
-          setSuccess(`Programa creado correctamente${scheduleMsg}, pero hubo un error al agregar algunos panelistas`);
+              body: JSON.stringify(bulkData),
+            });
+            if (!scheduleRes.ok) {
+              const scheduleBody = await scheduleRes.json().catch(() => ({}));
+              throw new Error(scheduleBody.details || scheduleBody.error || 'Error al crear los horarios');
+            }
+          } catch (scheduleErr) {
+            console.error('Error creating schedules:', scheduleErr);
+            setSuccess('Programa creado correctamente, pero hubo un error al crear algunos horarios');
+            await fetchPrograms();
+            fetchSchedulesForFilter();
+            handleCloseDialog();
+            return;
+          }
         }
-      } else if (!pendingSchedules.length && !pendingPanelistIds.length) {
-        setSuccess(editingProgram ? 'Programa actualizado correctamente' : 'Programa creado correctamente');
+
+        if (pendingPanelistIds.length > 0 && typedSession?.accessToken) {
+          try {
+            await Promise.all(
+              pendingPanelistIds.map(panelistId =>
+                fetch(`/api/panelists/${panelistId}/programs/${newProgramId}`, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${typedSession.accessToken}`,
+                  },
+                })
+              )
+            );
+          } catch (panelistErr) {
+            console.error('Error adding panelists:', panelistErr);
+          }
+        }
+
+        const scheduleMsg = pendingSchedules.length > 0 ? ` con ${pendingSchedules.length} horario(s)` : '';
+        const panelistMsg = pendingPanelistIds.length > 0 ? ` con ${pendingPanelistIds.length} panelista(s)` : '';
+        setSuccess(`Programa creado correctamente${scheduleMsg}${panelistMsg}`);
       }
 
       await fetchPrograms();
-      // Refresh schedule filter data after creating a program (it may now have schedules)
       fetchSchedulesForFilter();
       handleCloseDialog();
     } catch (err: unknown) {
@@ -505,12 +563,43 @@ export default function ProgramsPage() {
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 2 }}>
             <TextField label="Nombre" value={formData.name} onChange={e => setFormData({ ...formData, name: e.target.value })} fullWidth required />
             <TextField label="Descripción" multiline rows={3} value={formData.description} onChange={e => setFormData({ ...formData, description: e.target.value })} fullWidth />
-            <FormControl fullWidth>
-              <InputLabel>Canal</InputLabel>
-              <Select value={formData.channel_id} onChange={e => setFormData({ ...formData, channel_id: e.target.value as string })} label="Canal">
-                {channels.map(ch => <MenuItem key={ch.id} value={String(ch.id)}>{ch.name}</MenuItem>)}
-              </Select>
-            </FormControl>
+            {editingProgram ? (
+              <FormControl fullWidth>
+                <InputLabel>Canal</InputLabel>
+                <Select
+                  value={formData.channel_id}
+                  onChange={e => setFormData({ ...formData, channel_id: e.target.value as string })}
+                  label="Canal"
+                >
+                  {channels.map(ch => <MenuItem key={ch.id} value={String(ch.id)}>{ch.name}</MenuItem>)}
+                </Select>
+              </FormControl>
+            ) : (
+              <FormControl fullWidth>
+                <InputLabel>Canales</InputLabel>
+                <Select
+                  multiple
+                  value={formData.channel_ids}
+                  onChange={e => setFormData({ ...formData, channel_ids: e.target.value as string[] })}
+                  label="Canales"
+                  renderValue={(selected) => (
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {(selected as string[]).map(id => {
+                        const ch = channels.find(c => String(c.id) === id);
+                        return <Chip key={id} label={ch?.name ?? id} size="small" />;
+                      })}
+                    </Box>
+                  )}
+                >
+                  {channels.map(ch => <MenuItem key={ch.id} value={String(ch.id)}>{ch.name}</MenuItem>)}
+                </Select>
+                {formData.channel_ids.length > 1 && (
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                    Se crearán {formData.channel_ids.length} programas independientes (uno por canal)
+                  </Typography>
+                )}
+              </FormControl>
+            )}
             <TextField label="URL del logo" value={formData.logo_url} onChange={e => setFormData({ ...formData, logo_url: e.target.value })} fullWidth />
             <TextField label="URL de YouTube" value={formData.youtube_url} onChange={e => setFormData({ ...formData, youtube_url: e.target.value })} fullWidth />
             <TextField label="Estilo especial (opcional)" value={formData.style_override} onChange={e => setFormData({ ...formData, style_override: e.target.value })} fullWidth placeholder="boca, river, etc." />
@@ -535,7 +624,11 @@ export default function ProgramsPage() {
 
             <ProgramSchedulesSection
               programId={editingProgram?.id || null}
-              channelId={formData.channel_id ? parseInt(formData.channel_id) : null}
+              channelId={
+                editingProgram
+                  ? (formData.channel_id ? parseInt(formData.channel_id) : null)
+                  : (formData.channel_ids[0] ? parseInt(formData.channel_ids[0]) : null)
+              }
               onSchedulesChange={setPendingSchedules}
             />
 

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -31,6 +31,7 @@ import {
   Tooltip,
   InputAdornment,
   Chip,
+  Autocomplete,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -575,30 +576,41 @@ export default function ProgramsPage() {
                 </Select>
               </FormControl>
             ) : (
-              <FormControl fullWidth>
-                <InputLabel>Canales</InputLabel>
-                <Select
+              <Box>
+                <Autocomplete
                   multiple
-                  value={formData.channel_ids}
-                  onChange={e => setFormData({ ...formData, channel_ids: e.target.value as string[] })}
-                  label="Canales"
-                  renderValue={(selected) => (
-                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                      {(selected as string[]).map(id => {
-                        const ch = channels.find(c => String(c.id) === id);
-                        return <Chip key={id} label={ch?.name ?? id} size="small" />;
-                      })}
-                    </Box>
+                  disableCloseOnSelect
+                  options={channels}
+                  getOptionLabel={(ch) => ch.name}
+                  value={channels.filter(ch => formData.channel_ids.includes(String(ch.id)))}
+                  onChange={(_, newValue) =>
+                    setFormData({ ...formData, channel_ids: newValue.map(ch => String(ch.id)) })
+                  }
+                  renderInput={(params) => (
+                    <TextField {...params} label="Canales" placeholder={formData.channel_ids.length === 0 ? 'Seleccionar canales…' : ''} />
                   )}
-                >
-                  {channels.map(ch => <MenuItem key={ch.id} value={String(ch.id)}>{ch.name}</MenuItem>)}
-                </Select>
+                  renderTags={(value, getTagProps) =>
+                    value.map((ch, index) => {
+                      const { key, ...tagProps } = getTagProps({ index });
+                      return <Chip key={key} label={ch.name} size="small" {...tagProps} />;
+                    })
+                  }
+                  renderOption={(props, option, { selected }) => (
+                    <li {...props}>
+                      <Checkbox size="small" checked={selected} sx={{ mr: 1 }} />
+                      {option.name}
+                    </li>
+                  )}
+                  isOptionEqualToValue={(option, value) => option.id === value.id}
+                  limitTags={4}
+                  fullWidth
+                />
                 {formData.channel_ids.length > 1 && (
-                  <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
                     Se crearán {formData.channel_ids.length} programas independientes (uno por canal)
                   </Typography>
                 )}
-              </FormControl>
+              </Box>
             )}
             <TextField label="URL del logo" value={formData.logo_url} onChange={e => setFormData({ ...formData, logo_url: e.target.value })} fullWidth />
             <TextField label="URL de YouTube" value={formData.youtube_url} onChange={e => setFormData({ ...formData, youtube_url: e.target.value })} fullWidth />

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -39,6 +39,7 @@ import {
   Delete as DeleteIcon,
   Group as GroupIcon,
   Search as SearchIcon,
+  DeleteSweep as DeleteSweepIcon,
 } from '@mui/icons-material';
 import { Program } from '@/types/program';
 import { Channel } from '@/types/channel';
@@ -88,6 +89,10 @@ export default function ProgramsPage() {
   const [pendingSchedules, setPendingSchedules] = useState<PendingSchedule[]>([]);
   const [pendingPanelistIds, setPendingPanelistIds] = useState<number[]>([]);
 
+  // Multi-select & bulk delete
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [confirmBulkDeleteOpen, setConfirmBulkDeleteOpen] = useState(false);
+
   // Search / sort / filter / pagination
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState('name_asc');
@@ -105,9 +110,10 @@ export default function ProgramsPage() {
     }
   }, [status]);
 
-  // Reset to first page whenever search/sort/filter changes
+  // Reset to first page and clear selection whenever search/sort/filter changes
   useEffect(() => {
     setPage(0);
+    setSelectedIds(new Set());
   }, [searchTerm, sortBy, scheduleFilter]);
 
   const fetchPrograms = async () => {
@@ -402,6 +408,57 @@ export default function ProgramsPage() {
     }
   };
 
+  const handleToggleSelect = (id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const allPageSelected =
+    paginatedPrograms.length > 0 &&
+    paginatedPrograms.every(p => selectedIds.has(p.id));
+
+  const somePageSelected =
+    paginatedPrograms.some(p => selectedIds.has(p.id)) && !allPageSelected;
+
+  const handleSelectAllPage = () => {
+    if (allPageSelected) {
+      setSelectedIds(prev => {
+        const next = new Set(prev);
+        paginatedPrograms.forEach(p => next.delete(p.id));
+        return next;
+      });
+    } else {
+      setSelectedIds(prev => {
+        const next = new Set(prev);
+        paginatedPrograms.forEach(p => next.add(p.id));
+        return next;
+      });
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    setConfirmBulkDeleteOpen(false);
+    try {
+      await Promise.all(
+        [...selectedIds].map(id => fetch(`/api/programs/${id}`, { method: 'DELETE' }))
+      );
+      setSelectedIds(new Set());
+      await fetchPrograms();
+      fetchSchedulesForFilter();
+      setSuccess(`${selectedIds.size} programa(s) eliminado(s) correctamente`);
+    } catch (err: unknown) {
+      console.error('Error bulk deleting programs:', err);
+      setError('Error al eliminar los programas seleccionados');
+    }
+  };
+
   const handleCloseSnackbar = () => {
     setError(null);
     setSuccess(null);
@@ -480,7 +537,14 @@ export default function ProgramsPage() {
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>Logo</TableCell>
+              <TableCell padding="checkbox">
+                <Checkbox
+                  size="small"
+                  indeterminate={somePageSelected}
+                  checked={allPageSelected}
+                  onChange={handleSelectAllPage}
+                />
+              </TableCell>
               <TableCell>Nombre</TableCell>
               <TableCell>Canal</TableCell>
               <TableCell>YouTube</TableCell>
@@ -492,11 +556,17 @@ export default function ProgramsPage() {
             {paginatedPrograms.map(program => {
               const channel = channels.find(c => c.id === program.channel_id);
               return (
-                <TableRow key={program.id}>
-                  <TableCell>
-                    {program.logo_url && (
-                      <Image unoptimized src={program.logo_url} alt={program.name} width={50} height={50} style={{ objectFit: 'contain' }} />
-                    )}
+                <TableRow
+                  key={program.id}
+                  selected={selectedIds.has(program.id)}
+                  sx={{ cursor: 'pointer' }}
+                >
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      size="small"
+                      checked={selectedIds.has(program.id)}
+                      onChange={() => handleToggleSelect(program.id)}
+                    />
                   </TableCell>
                   <TableCell>{program.name}</TableCell>
                   <TableCell>
@@ -661,6 +731,79 @@ export default function ProgramsPage() {
       <Snackbar open={!!error || !!success} autoHideDuration={6000} onClose={handleCloseSnackbar}>
         <Alert severity={error ? 'error' : 'success'} onClose={handleCloseSnackbar}>{error || success}</Alert>
       </Snackbar>
+
+      {/* Floating bulk-action bar */}
+      {selectedIds.size > 0 && (
+        <Paper
+          elevation={8}
+          sx={{
+            position: 'fixed',
+            bottom: 32,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            px: 3,
+            py: 1.5,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            borderRadius: 3,
+            zIndex: 1300,
+          }}
+        >
+          <Typography variant="body2" fontWeight={600}>
+            {selectedIds.size} programa{selectedIds.size !== 1 ? 's' : ''} seleccionado{selectedIds.size !== 1 ? 's' : ''}
+          </Typography>
+          <Button
+            variant="text"
+            size="small"
+            onClick={() => setSelectedIds(new Set())}
+          >
+            Deseleccionar
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            startIcon={<DeleteSweepIcon />}
+            onClick={() => setConfirmBulkDeleteOpen(true)}
+          >
+            Eliminar seleccionados
+          </Button>
+        </Paper>
+      )}
+
+      {/* Bulk delete confirmation dialog */}
+      <Dialog open={confirmBulkDeleteOpen} onClose={() => setConfirmBulkDeleteOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Eliminar programas</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            ¿Estás seguro que querés eliminar los siguientes {selectedIds.size} programa{selectedIds.size !== 1 ? 's' : ''}?
+          </Typography>
+          <Box component="ul" sx={{ m: 0, pl: 2 }}>
+            {[...selectedIds].map(id => {
+              const p = programs.find(pr => pr.id === id);
+              const ch = channels.find(c => c.id === p?.channel_id);
+              return (
+                <li key={id}>
+                  <Typography variant="body2">
+                    <strong>{p?.name ?? `#${id}`}</strong>
+                    {ch ? ` — ${ch.name}` : ''}
+                  </Typography>
+                </li>
+              );
+            })}
+          </Box>
+          <Alert severity="warning" sx={{ mt: 2 }}>
+            Esta acción eliminará también todos los horarios y overrides asociados.
+          </Alert>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmBulkDeleteOpen(false)}>Cancelar</Button>
+          <Button variant="contained" color="error" onClick={handleBulkDelete}>
+            Eliminar {selectedIds.size} programa{selectedIds.size !== 1 ? 's' : ''}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -127,6 +127,7 @@ export function WeeklyOverridesTable() {
   const [channels, setChannels] = useState<{ id: number; name: string }[]>([]);
   const [editingOverride, setEditingOverride] = useState<WeeklyOverride | null>(null);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [specialChannelIds, setSpecialChannelIds] = useState<number[]>([]);
 
   // Fetch data
   const fetchData = useCallback(async () => {
@@ -269,6 +270,7 @@ export function WeeklyOverridesTable() {
     setEditingOverride(null);
     setIsEditMode(false);
     setPanelistSearchTerm('');
+    setSpecialChannelIds([]);
     setFormData({
       targetWeek: 'current',
       overrideType: 'cancel',
@@ -292,6 +294,45 @@ export function WeeklyOverridesTable() {
     if (!selectedSchedule && !selectedProgram && formData.overrideType !== 'create' && !isEditMode) return;
 
     try {
+      // Bulk path: special program (create) + multiple channels + not editing
+      if (formData.overrideType === 'create' && !isEditMode && specialChannelIds.length > 1) {
+        const bulkPayload = {
+          channel_ids: specialChannelIds,
+          targetWeek: formData.targetWeek,
+          overrideType: 'create' as const,
+          newStartTime: formData.newStartTime,
+          newEndTime: formData.newEndTime,
+          newDayOfWeek: formData.newDayOfWeek,
+          reason: formData.reason,
+          createdBy: typedSession?.user?.name || 'Admin',
+          ...(formData.panelistIds.length > 0 && { panelistIds: formData.panelistIds }),
+          specialProgram: {
+            name: formData.specialProgram.name,
+            description: formData.specialProgram.description || undefined,
+            imageUrl: formData.specialProgram.imageUrl || undefined,
+            stream_url: formData.specialProgram.stream_url || undefined,
+            is_premiere: formData.specialProgram.is_premiere,
+          },
+        };
+        const response = await fetch('/api/weekly-overrides/bulk', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${typedSession?.accessToken}`,
+          },
+          body: JSON.stringify(bulkPayload),
+        });
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || 'Error al crear los programas especiales');
+        }
+        setSuccess(`${specialChannelIds.length} programas especiales creados correctamente`);
+        handleCloseDialog();
+        await fetchData();
+        return;
+      }
+
+      // Single-channel or edit path (existing logic)
       interface OverridePayload {
         targetWeek: 'current' | 'next';
         overrideType: 'cancel' | 'time_change' | 'reschedule' | 'create';
@@ -313,6 +354,12 @@ export function WeeklyOverridesTable() {
         };
       }
 
+      // For single-channel create, use the first (and only) specialChannelId if set
+      const singleChannelId =
+        formData.overrideType === 'create' && !isEditMode && specialChannelIds.length === 1
+          ? specialChannelIds[0]
+          : formData.specialProgram.channelId;
+
       const payload: OverridePayload = {
         targetWeek: formData.targetWeek,
         overrideType: formData.overrideType,
@@ -325,9 +372,8 @@ export function WeeklyOverridesTable() {
         }),
         ...(formData.overrideType === 'create' && {
           newDayOfWeek: formData.newDayOfWeek,
-          specialProgram: formData.specialProgram,
+          specialProgram: { ...formData.specialProgram, channelId: singleChannelId },
         }),
-        // For edit mode, use the existing override's IDs; for create mode, use selected entities
         ...(isEditMode && editingOverride ? {
           ...(editingOverride.scheduleId && { scheduleId: editingOverride.scheduleId }),
           ...(editingOverride.programId && { programId: editingOverride.programId }),
@@ -346,12 +392,12 @@ export function WeeklyOverridesTable() {
         createdBy: typedSession?.user?.name || 'Admin',
       };
 
-      const url = isEditMode && editingOverride 
+      const url = isEditMode && editingOverride
         ? `/api/weekly-overrides/${editingOverride.id}`
         : '/api/weekly-overrides';
-      
+
       const method = isEditMode ? 'PUT' : 'POST';
-      
+
       const response = await fetch(url, {
         method,
         headers: {
@@ -1078,6 +1124,8 @@ export function WeeklyOverridesTable() {
             onClick={() => {
               setSelectedSchedule(null);
               setSelectedProgram(null);
+              setIsEditMode(false);
+              setSpecialChannelIds([]);
               setFormData({
                 targetWeek: 'current',
                 overrideType: 'create',
@@ -1406,26 +1454,53 @@ export function WeeklyOverridesTable() {
                   rows={2}
                 />
                 
-                {/* Channel selection dropdown */}
-                <FormControl fullWidth required>
-                  <InputLabel id="special-program-channel-label">Canal</InputLabel>
-                  <Select
-                    labelId="special-program-channel-label"
-                    value={formData.specialProgram.channelId}
-                    label="Canal"
-                    onChange={(e) => setFormData({
-                      ...formData,
-                      specialProgram: { ...formData.specialProgram, channelId: Number(e.target.value) }
-                    })}
-                  >
-                    {channels.map((channel) => (
-                      <MenuItem key={channel.id} value={channel.id}>{channel.name}</MenuItem>
-                    ))}
-                  </Select>
-                  <Typography variant="caption" color="text.secondary">
-                    Selecciona el canal donde se emitirá el programa
-                  </Typography>
-                </FormControl>
+                {/* Channel selection — multi-select when not editing */}
+                {isEditMode ? (
+                  <FormControl fullWidth required>
+                    <InputLabel id="special-program-channel-label">Canal</InputLabel>
+                    <Select
+                      labelId="special-program-channel-label"
+                      value={formData.specialProgram.channelId}
+                      label="Canal"
+                      onChange={(e) => setFormData({
+                        ...formData,
+                        specialProgram: { ...formData.specialProgram, channelId: Number(e.target.value) }
+                      })}
+                    >
+                      {channels.map((channel) => (
+                        <MenuItem key={channel.id} value={channel.id}>{channel.name}</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                ) : (
+                  <FormControl fullWidth required>
+                    <InputLabel id="special-program-channels-label">Canales</InputLabel>
+                    <Select
+                      labelId="special-program-channels-label"
+                      multiple
+                      value={specialChannelIds}
+                      label="Canales"
+                      onChange={(e) => setSpecialChannelIds(e.target.value as number[])}
+                      renderValue={(selected) => (
+                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                          {(selected as number[]).map(id => {
+                            const ch = channels.find(c => c.id === id);
+                            return <Chip key={id} label={ch?.name ?? id} size="small" />;
+                          })}
+                        </Box>
+                      )}
+                    >
+                      {channels.map((channel) => (
+                        <MenuItem key={channel.id} value={channel.id}>{channel.name}</MenuItem>
+                      ))}
+                    </Select>
+                    {specialChannelIds.length > 1 && (
+                      <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                        Se crearán {specialChannelIds.length} programas especiales independientes (uno por canal)
+                      </Typography>
+                    )}
+                  </FormControl>
+                )}
                 
                 <TextField
                   label="URL de imagen (opcional)"

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -1473,33 +1473,39 @@ export function WeeklyOverridesTable() {
                     </Select>
                   </FormControl>
                 ) : (
-                  <FormControl fullWidth required>
-                    <InputLabel id="special-program-channels-label">Canales</InputLabel>
-                    <Select
-                      labelId="special-program-channels-label"
+                  <Box>
+                    <Autocomplete
                       multiple
-                      value={specialChannelIds}
-                      label="Canales"
-                      onChange={(e) => setSpecialChannelIds(e.target.value as number[])}
-                      renderValue={(selected) => (
-                        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                          {(selected as number[]).map(id => {
-                            const ch = channels.find(c => c.id === id);
-                            return <Chip key={id} label={ch?.name ?? id} size="small" />;
-                          })}
-                        </Box>
+                      disableCloseOnSelect
+                      options={channels}
+                      getOptionLabel={(ch) => ch.name}
+                      value={channels.filter(ch => specialChannelIds.includes(ch.id))}
+                      onChange={(_, newValue) => setSpecialChannelIds(newValue.map(ch => ch.id))}
+                      renderInput={(params) => (
+                        <TextField {...params} label="Canales" placeholder={specialChannelIds.length === 0 ? 'Seleccionar canales…' : ''} required />
                       )}
-                    >
-                      {channels.map((channel) => (
-                        <MenuItem key={channel.id} value={channel.id}>{channel.name}</MenuItem>
-                      ))}
-                    </Select>
+                      renderTags={(value, getTagProps) =>
+                        value.map((ch, index) => {
+                          const { key, ...tagProps } = getTagProps({ index });
+                          return <Chip key={key} label={ch.name} size="small" {...tagProps} />;
+                        })
+                      }
+                      renderOption={(props, option, { selected }) => (
+                        <li {...props}>
+                          <Checkbox size="small" checked={selected} sx={{ mr: 1 }} />
+                          {option.name}
+                        </li>
+                      )}
+                      isOptionEqualToValue={(option, value) => option.id === value.id}
+                      limitTags={4}
+                      fullWidth
+                    />
                     {specialChannelIds.length > 1 && (
-                      <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+                      <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
                         Se crearán {specialChannelIds.length} programas especiales independientes (uno por canal)
                       </Typography>
                     )}
-                  </FormControl>
+                  </Box>
                 )}
                 
                 <TextField

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -521,17 +521,22 @@ export function WeeklyOverridesTable() {
     }
   };
 
-  // Special-program multi-select helpers
+  // Multi-select helpers (shared across tabs 0, 1, 4)
   const specialProgramOverrides = [...currentWeekOverrides, ...nextWeekOverrides].filter(
     o => o.overrideType === 'create',
   );
 
-  const allSpecialSelected =
-    specialProgramOverrides.length > 0 &&
-    specialProgramOverrides.every(o => selectedOverrideIds.has(o.id));
+  const visibleOverrides =
+    currentTab === 0 ? currentWeekOverrides :
+    currentTab === 1 ? nextWeekOverrides :
+    currentTab === 4 ? specialProgramOverrides :
+    [];
 
-  const someSpecialSelected =
-    specialProgramOverrides.some(o => selectedOverrideIds.has(o.id)) && !allSpecialSelected;
+  const allVisibleSelected =
+    visibleOverrides.length > 0 && visibleOverrides.every(o => selectedOverrideIds.has(o.id));
+
+  const someVisibleSelected =
+    visibleOverrides.some(o => selectedOverrideIds.has(o.id)) && !allVisibleSelected;
 
   const handleToggleOverride = (id: string) => {
     setSelectedOverrideIds(prev => {
@@ -545,11 +550,11 @@ export function WeeklyOverridesTable() {
     });
   };
 
-  const handleSelectAllSpecial = () => {
-    if (allSpecialSelected) {
+  const handleSelectAllVisible = () => {
+    if (allVisibleSelected) {
       setSelectedOverrideIds(new Set());
     } else {
-      setSelectedOverrideIds(new Set(specialProgramOverrides.map(o => o.id)));
+      setSelectedOverrideIds(new Set(visibleOverrides.map(o => o.id)));
     }
   };
 
@@ -564,12 +569,12 @@ export function WeeklyOverridesTable() {
           }),
         ),
       );
-      setSuccess(`${selectedOverrideIds.size} programa(s) especial(es) eliminado(s) correctamente`);
+      setSuccess(`${selectedOverrideIds.size} cambio(s) eliminado(s) correctamente`);
       setSelectedOverrideIds(new Set());
       await fetchData();
     } catch (err) {
       console.error('Error bulk deleting overrides:', err);
-      setError('Error al eliminar los programas especiales seleccionados');
+      setError('Error al eliminar los cambios seleccionados');
     }
   };
 
@@ -673,7 +678,7 @@ export function WeeklyOverridesTable() {
 
       {/* Tabs */}
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
-        <Tabs value={currentTab} onChange={(_, newValue) => setCurrentTab(newValue)}>
+        <Tabs value={currentTab} onChange={(_, newValue) => { setCurrentTab(newValue); setSelectedOverrideIds(new Set()); }}>
           <Tab 
             label={`Semana Actual (${currentWeekOverrides.length} cambios)`} 
             sx={{ fontWeight: 600, color: 'text.primary' }}
@@ -703,6 +708,14 @@ export function WeeklyOverridesTable() {
           <Table>
             <TableHead>
               <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    size="small"
+                    indeterminate={someVisibleSelected}
+                    checked={allVisibleSelected}
+                    onChange={handleSelectAllVisible}
+                  />
+                </TableCell>
                 <TableCell>Programa</TableCell>
                 <TableCell>Tipo</TableCell>
                 <TableCell>Horario Original</TableCell>
@@ -717,9 +730,16 @@ export function WeeklyOverridesTable() {
                 const schedule = override.scheduleId ? schedules.find(s => s.id === override.scheduleId) : null;
                 const program = override.programId ? programs.find(p => p.id === override.programId) : null;
                 const Icon = getOverrideIcon(override.overrideType);
-                
+
                 return (
-                  <TableRow key={override.id}>
+                  <TableRow key={override.id} selected={selectedOverrideIds.has(override.id)}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        size="small"
+                        checked={selectedOverrideIds.has(override.id)}
+                        onChange={() => handleToggleOverride(override.id)}
+                      />
+                    </TableCell>
                     <TableCell>
                       <Typography variant="body2" fontWeight="bold">
                         {override.overrideType === 'create' 
@@ -806,6 +826,14 @@ export function WeeklyOverridesTable() {
           <Table>
             <TableHead>
               <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    size="small"
+                    indeterminate={someVisibleSelected}
+                    checked={allVisibleSelected}
+                    onChange={handleSelectAllVisible}
+                  />
+                </TableCell>
                 <TableCell>Programa</TableCell>
                 <TableCell>Tipo</TableCell>
                 <TableCell>Horario Original</TableCell>
@@ -820,9 +848,16 @@ export function WeeklyOverridesTable() {
                 const schedule = override.scheduleId ? schedules.find(s => s.id === override.scheduleId) : null;
                 const program = override.programId ? programs.find(p => p.id === override.programId) : null;
                 const Icon = getOverrideIcon(override.overrideType);
-                
+
                 return (
-                  <TableRow key={override.id}>
+                  <TableRow key={override.id} selected={selectedOverrideIds.has(override.id)}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        size="small"
+                        checked={selectedOverrideIds.has(override.id)}
+                        onChange={() => handleToggleOverride(override.id)}
+                      />
+                    </TableCell>
                     <TableCell>
                       <Typography variant="body2" fontWeight="bold">
                         {override.overrideType === 'create' 
@@ -1219,9 +1254,9 @@ export function WeeklyOverridesTable() {
                   <TableCell padding="checkbox">
                     <Checkbox
                       size="small"
-                      indeterminate={someSpecialSelected}
-                      checked={allSpecialSelected}
-                      onChange={handleSelectAllSpecial}
+                      indeterminate={someVisibleSelected}
+                      checked={allVisibleSelected}
+                      onChange={handleSelectAllVisible}
                     />
                   </TableCell>
                   <TableCell>Programa</TableCell>
@@ -1730,8 +1765,8 @@ export function WeeklyOverridesTable() {
         </Alert>
       </Snackbar>
 
-      {/* Floating bulk-action bar for special programs */}
-      {currentTab === 4 && selectedOverrideIds.size > 0 && (
+      {/* Floating bulk-action bar (tabs 0, 1, 4) */}
+      {[0, 1, 4].includes(currentTab) && selectedOverrideIds.size > 0 && (
         <Paper
           elevation={8}
           sx={{
@@ -1749,7 +1784,7 @@ export function WeeklyOverridesTable() {
           }}
         >
           <Typography variant="body2" fontWeight={600}>
-            {selectedOverrideIds.size} programa{selectedOverrideIds.size !== 1 ? 's' : ''} especial{selectedOverrideIds.size !== 1 ? 'es' : ''} seleccionado{selectedOverrideIds.size !== 1 ? 's' : ''}
+            {selectedOverrideIds.size} cambio{selectedOverrideIds.size !== 1 ? 's' : ''} seleccionado{selectedOverrideIds.size !== 1 ? 's' : ''}
           </Typography>
           <Button variant="text" size="small" onClick={() => setSelectedOverrideIds(new Set())}>
             Deseleccionar
@@ -1766,32 +1801,49 @@ export function WeeklyOverridesTable() {
         </Paper>
       )}
 
-      {/* Bulk delete confirmation dialog for special programs */}
+      {/* Bulk delete confirmation dialog */}
       <Dialog
         open={confirmBulkOverrideDeleteOpen}
         onClose={() => setConfirmBulkOverrideDeleteOpen(false)}
         maxWidth="sm"
         fullWidth
       >
-        <DialogTitle>Eliminar programas especiales</DialogTitle>
+        <DialogTitle>Eliminar cambios semanales</DialogTitle>
         <DialogContent>
           <Typography variant="body2" sx={{ mb: 2 }}>
-            ¿Estás seguro que querés eliminar los siguientes {selectedOverrideIds.size} programa{selectedOverrideIds.size !== 1 ? 's' : ''} especial{selectedOverrideIds.size !== 1 ? 'es' : ''}?
+            ¿Estás seguro que querés eliminar los siguientes {selectedOverrideIds.size} cambio{selectedOverrideIds.size !== 1 ? 's' : ''}?
           </Typography>
           <Box component="ul" sx={{ m: 0, pl: 2 }}>
             {[...selectedOverrideIds].map(id => {
-              const o = specialProgramOverrides.find(sp => sp.id === id);
-              const ch = channels.find(c => c.id === o?.specialProgram?.channelId);
+              const allOverrides = [...currentWeekOverrides, ...nextWeekOverrides];
+              const o = allOverrides.find(ov => ov.id === id);
+              if (!o) return <li key={id}><Typography variant="body2">{id}</Typography></li>;
+
+              const programName =
+                o.overrideType === 'create'
+                  ? o.specialProgram?.name || 'Programa especial'
+                  : programs.find(p => p.id === o.programId)?.name ||
+                    schedules.find(s => s.id === o.scheduleId)?.program.name ||
+                    'Programa desconocido';
+
+              const channelName =
+                o.overrideType === 'create'
+                  ? channels.find(c => c.id === o.specialProgram?.channelId)?.name || `Canal ID: ${o.specialProgram?.channelId || 'N/A'}`
+                  : programs.find(p => p.id === o.programId)?.channel_name ||
+                    schedules.find(s => s.id === o.scheduleId)?.program.channel?.name ||
+                    '';
+
+              const typeLabel = getOverrideLabel(o.overrideType);
+              const weekLabel = o.weekStartDate === currentWeekOverrides[0]?.weekStartDate ? 'Semana actual' : 'Próxima semana';
+
               return (
                 <li key={id}>
                   <Typography variant="body2">
-                    <strong>{o?.specialProgram?.name ?? id}</strong>
-                    {ch ? ` — ${ch.name}` : o?.specialProgram?.channelId ? ` — Canal ID: ${o.specialProgram.channelId}` : ''}
-                    {o && (
-                      <Typography component="span" variant="caption" color="text.secondary">
-                        {' '}({o.weekStartDate === currentWeekOverrides[0]?.weekStartDate ? 'Semana actual' : 'Próxima semana'}, {getDayLabel(o.newDayOfWeek || '')} {formatTime(o.newStartTime || '')}-{formatTime(o.newEndTime || '')})
-                      </Typography>
-                    )}
+                    <strong>{programName}</strong>
+                    {channelName ? ` — ${channelName}` : ''}
+                    <Typography component="span" variant="caption" color="text.secondary">
+                      {` · ${typeLabel} · ${weekLabel}`}
+                    </Typography>
                   </Typography>
                 </li>
               );
@@ -1801,7 +1853,7 @@ export function WeeklyOverridesTable() {
         <DialogActions>
           <Button onClick={() => setConfirmBulkOverrideDeleteOpen(false)}>Cancelar</Button>
           <Button variant="contained" color="error" onClick={handleBulkOverrideDelete}>
-            Eliminar {selectedOverrideIds.size} programa{selectedOverrideIds.size !== 1 ? 's' : ''}
+            Eliminar {selectedOverrideIds.size} cambio{selectedOverrideIds.size !== 1 ? 's' : ''}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -129,6 +129,10 @@ export function WeeklyOverridesTable() {
   const [isEditMode, setIsEditMode] = useState(false);
   const [specialChannelIds, setSpecialChannelIds] = useState<number[]>([]);
 
+  // Multi-select & bulk delete for special programs
+  const [selectedOverrideIds, setSelectedOverrideIds] = useState<Set<string>>(new Set());
+  const [confirmBulkOverrideDeleteOpen, setConfirmBulkOverrideDeleteOpen] = useState(false);
+
   // Fetch data
   const fetchData = useCallback(async () => {
     if (!typedSession?.accessToken) return;
@@ -514,6 +518,58 @@ export function WeeklyOverridesTable() {
     } catch (err) {
       console.error('Error during reset:', err);
       setError('Error durante el reset');
+    }
+  };
+
+  // Special-program multi-select helpers
+  const specialProgramOverrides = [...currentWeekOverrides, ...nextWeekOverrides].filter(
+    o => o.overrideType === 'create',
+  );
+
+  const allSpecialSelected =
+    specialProgramOverrides.length > 0 &&
+    specialProgramOverrides.every(o => selectedOverrideIds.has(o.id));
+
+  const someSpecialSelected =
+    specialProgramOverrides.some(o => selectedOverrideIds.has(o.id)) && !allSpecialSelected;
+
+  const handleToggleOverride = (id: string) => {
+    setSelectedOverrideIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleSelectAllSpecial = () => {
+    if (allSpecialSelected) {
+      setSelectedOverrideIds(new Set());
+    } else {
+      setSelectedOverrideIds(new Set(specialProgramOverrides.map(o => o.id)));
+    }
+  };
+
+  const handleBulkOverrideDelete = async () => {
+    setConfirmBulkOverrideDeleteOpen(false);
+    try {
+      await Promise.all(
+        [...selectedOverrideIds].map(id =>
+          fetch(`/api/weekly-overrides/${id}`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${typedSession?.accessToken}` },
+          }),
+        ),
+      );
+      setSuccess(`${selectedOverrideIds.size} programa(s) especial(es) eliminado(s) correctamente`);
+      setSelectedOverrideIds(new Set());
+      await fetchData();
+    } catch (err) {
+      console.error('Error bulk deleting overrides:', err);
+      setError('Error al eliminar los programas especiales seleccionados');
     }
   };
 
@@ -1160,6 +1216,14 @@ export function WeeklyOverridesTable() {
             <Table>
               <TableHead>
                 <TableRow>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      size="small"
+                      indeterminate={someSpecialSelected}
+                      checked={allSpecialSelected}
+                      onChange={handleSelectAllSpecial}
+                    />
+                  </TableCell>
                   <TableCell>Programa</TableCell>
                   <TableCell>Canal</TableCell>
                   <TableCell>Horario</TableCell>
@@ -1169,11 +1233,17 @@ export function WeeklyOverridesTable() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {[...currentWeekOverrides, ...nextWeekOverrides]
-                  .filter(override => override.overrideType === 'create')
+                {specialProgramOverrides
                   .map((override) => {
                     return (
-                      <TableRow key={override.id}>
+                      <TableRow key={override.id} selected={selectedOverrideIds.has(override.id)}>
+                        <TableCell padding="checkbox">
+                          <Checkbox
+                            size="small"
+                            checked={selectedOverrideIds.has(override.id)}
+                            onChange={() => handleToggleOverride(override.id)}
+                          />
+                        </TableCell>
                         <TableCell>
                           <Typography variant="body2" fontWeight="bold">
                             {override.specialProgram?.name || 'Programa especial'}
@@ -1659,6 +1729,82 @@ export function WeeklyOverridesTable() {
           {error || success}
         </Alert>
       </Snackbar>
+
+      {/* Floating bulk-action bar for special programs */}
+      {currentTab === 4 && selectedOverrideIds.size > 0 && (
+        <Paper
+          elevation={8}
+          sx={{
+            position: 'fixed',
+            bottom: 32,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            px: 3,
+            py: 1.5,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            borderRadius: 3,
+            zIndex: 1300,
+          }}
+        >
+          <Typography variant="body2" fontWeight={600}>
+            {selectedOverrideIds.size} programa{selectedOverrideIds.size !== 1 ? 's' : ''} especial{selectedOverrideIds.size !== 1 ? 'es' : ''} seleccionado{selectedOverrideIds.size !== 1 ? 's' : ''}
+          </Typography>
+          <Button variant="text" size="small" onClick={() => setSelectedOverrideIds(new Set())}>
+            Deseleccionar
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            size="small"
+            startIcon={<Delete />}
+            onClick={() => setConfirmBulkOverrideDeleteOpen(true)}
+          >
+            Eliminar seleccionados
+          </Button>
+        </Paper>
+      )}
+
+      {/* Bulk delete confirmation dialog for special programs */}
+      <Dialog
+        open={confirmBulkOverrideDeleteOpen}
+        onClose={() => setConfirmBulkOverrideDeleteOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Eliminar programas especiales</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            ¿Estás seguro que querés eliminar los siguientes {selectedOverrideIds.size} programa{selectedOverrideIds.size !== 1 ? 's' : ''} especial{selectedOverrideIds.size !== 1 ? 'es' : ''}?
+          </Typography>
+          <Box component="ul" sx={{ m: 0, pl: 2 }}>
+            {[...selectedOverrideIds].map(id => {
+              const o = specialProgramOverrides.find(sp => sp.id === id);
+              const ch = channels.find(c => c.id === o?.specialProgram?.channelId);
+              return (
+                <li key={id}>
+                  <Typography variant="body2">
+                    <strong>{o?.specialProgram?.name ?? id}</strong>
+                    {ch ? ` — ${ch.name}` : o?.specialProgram?.channelId ? ` — Canal ID: ${o.specialProgram.channelId}` : ''}
+                    {o && (
+                      <Typography component="span" variant="caption" color="text.secondary">
+                        {' '}({o.weekStartDate === currentWeekOverrides[0]?.weekStartDate ? 'Semana actual' : 'Próxima semana'}, {getDayLabel(o.newDayOfWeek || '')} {formatTime(o.newStartTime || '')}-{formatTime(o.newEndTime || '')})
+                      </Typography>
+                    )}
+                  </Typography>
+                </li>
+              );
+            })}
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmBulkOverrideDeleteOpen(false)}>Cancelar</Button>
+          <Button variant="contained" color="error" onClick={handleBulkOverrideDelete}>
+            Eliminar {selectedOverrideIds.size} programa{selectedOverrideIds.size !== 1 ? 's' : ''}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 } 


### PR DESCRIPTION
## Summary

- **Página Programas**: selector de canal cambiado a multi-select (`Autocomplete` MUI) al crear — si se eligen 2+ canales llama a `POST /api/programs/bulk`; con 1 canal mantiene el flujo existente con soporte de panelistas
- **Página Cambios Semanales — tab Programas Especiales**: selector de canal también multi-select al crear; 2+ canales llama a `POST /api/weekly-overrides/bulk`
- **Borrado masivo en Programas**: columna de checkbox reemplaza "Logo"; barra flotante + diálogo de confirmación con `nombre — canal` al seleccionar ≥1 programa
- **Borrado masivo en Cambios Semanales** (tabs Semana Actual, Próxima Semana y Programas Especiales): mismo patrón — checkbox column, select-all, barra flotante, diálogo de confirmación con tipo de cambio y semana
- Nuevas rutas API proxy: `/api/programs/bulk` y `/api/weekly-overrides/bulk`

## Test plan

- [ ] Crear programa con 1 canal → flujo normal con panelistas
- [ ] Crear programa con 3 canales → llama a bulk endpoint, crea 3 programas independientes
- [ ] Selector de canal en "Programas Especiales" multi-select con Autocomplete
- [ ] Crear programa especial para 2 canales → 2 overrides en Redis
- [ ] Seleccionar múltiples programas → barra flotante aparece con count correcto
- [ ] Confirmar borrado → muestra lista con nombre y canal
- [ ] Seleccionar múltiples cambios semanales en tabs 0, 1 y 4 → borrado masivo funciona
- [ ] Cambiar de tab limpia la selección

🤖 Generated with [Claude Code](https://claude.com/claude-code)