### PR TITLE
🎨 Palette: Add Tooltips to YouTube Global Player controls

### DIFF
--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, Typography, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Tooltip, Typography, useMediaQuery } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
@@ -304,17 +304,19 @@ export const YouTubeGlobalPlayer = () => {
           >
             {/* Zap toggle */}
             {!minimized && hasZapItems && (
-              <IconButton
-                aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
-                onClick={() => setZapOpen((v) => !v)}
-                size="small"
-                sx={{
-                  color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
-                  '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
-                }}
-              >
-                <FormatListBulletedIcon fontSize="small" />
-              </IconButton>
+              <Tooltip title={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'} arrow>
+                <IconButton
+                  aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
+                  onClick={() => setZapOpen((v) => !v)}
+                  size="small"
+                  sx={{
+                    color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
+                    '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
+                  }}
+                >
+                  <FormatListBulletedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
             )}
 
             {/* Channel / streamer mini-logo + name */}
@@ -367,23 +369,27 @@ export const YouTubeGlobalPlayer = () => {
 
             <Box sx={{ flex: 1 }} />
 
-            <IconButton
-              aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
-              onClick={minimized ? maximizePlayer : minimizePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'} arrow>
+              <IconButton
+                aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
+                onClick={minimized ? maximizePlayer : minimizePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
 
-            <IconButton
-              aria-label="Cerrar reproductor"
-              onClick={closePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CloseIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Cerrar reproductor" arrow>
+              <IconButton
+                aria-label="Cerrar reproductor"
+                onClick={closePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           </Box>
 
           {/* iframe */}


### PR DESCRIPTION
**💡 What:** 
Added Material UI Tooltips to the icon-only buttons in the `YouTubeGlobalPlayer` component. The tooltips show titles matching the existing `aria-label` values for the channel list toggle, the maximize/minimize toggle, and the close button.

**🎯 Why:**
Icon-only buttons can be ambiguous to sighted users who aren't familiar with the icons. Adding tooltips makes the interface more intuitive and provides immediate, context-sensitive help when hovering over the controls. This improves overall usability, especially for the non-standard "zap" list icon.

**♿ Accessibility:**
The tooltips accurately mirror the existing `aria-label`s, ensuring consistency. Sighted keyboard users traversing focus will also see the tooltips, improving accessibility for keyboard-only navigation.

---
*PR created automatically by Jules for task [14604547372847982342](https://jules.google.com/task/14604547372847982342) started by @matiasrozenblum*