### PR TITLE
Release 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 - **Creación de programas especiales en múltiples canales**: el selector de canal en el tab "Programas Especiales" también es multi-select; con 2+ canales se llama a `POST /api/weekly-overrides/bulk`.
 - **Borrado masivo de programas**: la columna "Logo" (sin uso) fue reemplazada por una columna de checkbox. Al seleccionar ≥1 programa aparece una barra flotante con la opción de eliminar, con diálogo de confirmación que lista `nombre — canal` de cada programa.
 - **Borrado masivo de cambios semanales**: misma mecánica de checkbox + barra flotante + diálogo de confirmación en los tabs "Semana Actual", "Próxima Semana" y "Programas Especiales". La selección se limpia automáticamente al cambiar de tab.
+- **Programas linkeados — UI de backoffice**: ícono de vínculo en la tabla de programas cuando un programa tiene `link_group_id`. Diálogo de confirmación de borrado advierte que eliminar un programa linkeado no afecta al resto del grupo.
+- **Diálogo de resolución de conflictos** (`ConflictResolutionDialog`): tras crear o editar un weekly override, si el backend detecta solapamientos en la grilla se muestra automáticamente un diálogo que lista cada conflicto agrupado por canal, con sugerencia automática de acción (ajustar horario o cancelar) y pickers de tiempo editables. Las resoluciones se envían a `POST /api/weekly-overrides/resolve-conflicts`.
+
+### Fixed
+
+- El tab "Programas Especiales" de weekly overrides ahora muestra el nombre del canal en vez del ID numérico para overrides de tipo `create`.
+- **Banner web — scroll en dos fases**: el banner ahora se desplaza hacia arriba y desaparece completamente antes de que la grilla empiece a moverse, replicando el comportamiento de la app nativa. El offset del banner se actualiza mediante mutación directa del DOM (sin re-renders de React) para evitar fricción en el scroll.
+- Fondo del área de over-scroll (bounce) ahora coincide con el color de fondo del tema (oscuro `#0f172a` / claro `#f8fafc`) en lugar de mostrar blanco.
 
 ## [1.24.0] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 
-## [Unreleased]
+## [1.26.0] - 2026-06-23
 
 ### Added
 

--- a/src/app/api/programs/[id]/route.ts
+++ b/src/app/api/programs/[id]/route.ts
@@ -89,14 +89,16 @@ export async function DELETE(
 ) {
   try {
     const token = await requireAccessToken(request);
-    
+
     if (!token) {
       console.error('No authentication token found');
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const { id } = await params;
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/programs/${id}`, {
+    const deleteLinked = request.nextUrl.searchParams.get('deleteLinked');
+    const url = `${process.env.NEXT_PUBLIC_API_URL}/programs/${id}${deleteLinked === 'true' ? '?deleteLinked=true' : ''}`;
+    const response = await fetch(url, {
       method: 'DELETE',
       headers: {
         'Authorization': `Bearer ${token}`,

--- a/src/app/api/weekly-overrides/resolve-conflicts/route.ts
+++ b/src/app/api/weekly-overrides/resolve-conflicts/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAccessToken } from '@/utils/auth-server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = await requireAccessToken(request);
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const body = await request.json();
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/weekly-overrides/resolve-conflicts`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    const data = await response.json().catch(() => ({}));
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Failed to resolve conflicts',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -40,6 +40,7 @@ import {
   Group as GroupIcon,
   Search as SearchIcon,
   DeleteSweep as DeleteSweepIcon,
+  Link as LinkIcon,
 } from '@mui/icons-material';
 import { Program } from '@/types/program';
 import { Channel } from '@/types/channel';
@@ -92,6 +93,9 @@ export default function ProgramsPage() {
   // Multi-select & bulk delete
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [confirmBulkDeleteOpen, setConfirmBulkDeleteOpen] = useState(false);
+
+  // Linked-program delete dialog
+  const [linkedDeleteDialog, setLinkedDeleteDialog] = useState<{ open: boolean; program: Program | null }>({ open: false, program: null });
 
   // Search / sort / filter / pagination
   const [searchTerm, setSearchTerm] = useState('');
@@ -273,7 +277,7 @@ export default function ProgramsPage() {
         if (!res.ok) throw new Error(body.details || body.error || 'Error al actualizar el programa');
         setSuccess('Programa actualizado correctamente');
       } else if (formData.channel_ids.length > 1) {
-        // Bulk create: multiple channels → single API call, no panelists
+        // Bulk create: multiple channels → linked programs
         const scheduleItems = pendingSchedules.map(s => ({
           startTime: s.startTime,
           endTime: s.endTime,
@@ -295,12 +299,14 @@ export default function ProgramsPage() {
             is_visible: formData.is_visible,
             is_premiere: formData.is_premiere,
             ...(scheduleItems.length > 0 && { schedules: scheduleItems }),
+            ...(pendingPanelistIds.length > 0 && { panelist_ids: pendingPanelistIds }),
           }),
         });
         const body = await res.json();
         if (!res.ok) throw new Error(body.details || body.error || 'Error al crear los programas');
         const scheduleMsg = pendingSchedules.length > 0 ? ` con ${pendingSchedules.length} horario(s)` : '';
-        setSuccess(`${formData.channel_ids.length} programas creados correctamente${scheduleMsg}`);
+        const panelistMsg = pendingPanelistIds.length > 0 ? ` con ${pendingPanelistIds.length} panelista(s)` : '';
+        setSuccess(`${formData.channel_ids.length} programas vinculados creados correctamente${scheduleMsg}${panelistMsg}`);
       } else {
         // Single channel create — existing flow
         const channelId = parseInt(formData.channel_ids[0] ?? formData.channel_id);
@@ -391,17 +397,26 @@ export default function ProgramsPage() {
     }
   };
 
-  const handleDelete = async (id: number) => {
-    if (!confirm('¿Estás seguro que deseas eliminar este programa?')) return;
+  const handleDelete = (program: Program) => {
+    if (program.link_group_id) {
+      setLinkedDeleteDialog({ open: true, program });
+    } else {
+      handleDeleteConfirmed(program.id, false);
+    }
+  };
+
+  const handleDeleteConfirmed = async (id: number, deleteLinked: boolean) => {
+    setLinkedDeleteDialog({ open: false, program: null });
     try {
-      const res = await fetch(`/api/programs/${id}`, { method: 'DELETE' });
+      const url = deleteLinked ? `/api/programs/${id}?deleteLinked=true` : `/api/programs/${id}`;
+      const res = await fetch(url, { method: 'DELETE' });
       if (!res.ok) {
         const body = await res.json().catch(() => null);
         throw new Error(body?.details || 'Error al eliminar el programa');
       }
       await fetchPrograms();
       fetchSchedulesForFilter();
-      setSuccess('Programa eliminado correctamente');
+      setSuccess(deleteLinked ? 'Programas vinculados eliminados correctamente' : 'Programa eliminado correctamente');
     } catch (err: unknown) {
       console.error('Error deleting program:', err);
       setError(err instanceof Error ? err.message : 'Error al eliminar el programa');
@@ -568,7 +583,16 @@ export default function ProgramsPage() {
                       onChange={() => handleToggleSelect(program.id)}
                     />
                   </TableCell>
-                  <TableCell>{program.name}</TableCell>
+                  <TableCell>
+                    <Box display="flex" alignItems="center" gap={0.5}>
+                      {program.link_group_id && (
+                        <Tooltip title="Programa vinculado" arrow>
+                          <LinkIcon fontSize="small" color="primary" />
+                        </Tooltip>
+                      )}
+                      {program.name}
+                    </Box>
+                  </TableCell>
                   <TableCell>
                     <Box display="flex" alignItems="center" gap={1}>
                       {channel?.logo_url && (
@@ -599,7 +623,7 @@ export default function ProgramsPage() {
                       <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
                     </Tooltip>
                     <Tooltip title="Eliminar programa" arrow>
-                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program.id)}><DeleteIcon /></IconButton>
+                      <IconButton aria-label="Eliminar programa" onClick={() => handleDelete(program)}><DeleteIcon /></IconButton>
                     </Tooltip>
                     <Tooltip title="Gestionar panelistas" arrow>
                       <IconButton aria-label="Gestionar panelistas" onClick={() => { setEditingProgram(program); handleOpenPanelistsDialog(); }}>
@@ -677,7 +701,7 @@ export default function ProgramsPage() {
                 />
                 {formData.channel_ids.length > 1 && (
                   <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
-                    Se crearán {formData.channel_ids.length} programas independientes (uno por canal)
+                    Se crearán {formData.channel_ids.length} programas vinculados (uno por canal). Cambios en cualquiera se propagan a todos.
                   </Typography>
                 )}
               </Box>
@@ -771,6 +795,28 @@ export default function ProgramsPage() {
           </Button>
         </Paper>
       )}
+
+      {/* Linked-program delete dialog */}
+      <Dialog open={linkedDeleteDialog.open} onClose={() => setLinkedDeleteDialog({ open: false, program: null })} maxWidth="sm" fullWidth>
+        <DialogTitle>Eliminar programa vinculado</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            <strong>{linkedDeleteDialog.program?.name}</strong> está vinculado a otro/s canal/es. ¿Qué querés eliminar?
+          </Typography>
+          <Alert severity="warning">
+            Eliminar todos los vinculados borrará también los horarios y overrides de cada uno.
+          </Alert>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setLinkedDeleteDialog({ open: false, program: null })}>Cancelar</Button>
+          <Button onClick={() => handleDeleteConfirmed(linkedDeleteDialog.program!.id, false)}>
+            Solo este canal
+          </Button>
+          <Button variant="contained" color="error" onClick={() => handleDeleteConfirmed(linkedDeleteDialog.program!.id, true)}>
+            Eliminar todos los vinculados
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* Bulk delete confirmation dialog */}
       <Dialog open={confirmBulkDeleteOpen} onClose={() => setConfirmBulkDeleteOpen(false)} maxWidth="sm" fullWidth>

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -62,8 +62,9 @@ export default function HomeClient({ initialData }: HomeClientProps) {
   const [showHoliday, setShowHoliday] = useState(initialData.holiday);
   const [showSeasonal, setShowSeasonal] = useState(isSeasonActive);
   const [banners, setBanners] = useState<Banner[]>(initialData.banners || []);
-  const [bannerVisible, setBannerVisible] = useState(true);
   const bannerContainerRef = useRef<HTMLDivElement>(null);
+  const bannerOuterRef = useRef<HTMLDivElement>(null);
+  const bannerOffsetRef = useRef(0);
 
   const { mode } = useThemeContext();
   const { setLiveStatuses, liveStatus } = useLiveStatus();
@@ -89,6 +90,12 @@ export default function HomeClient({ initialData }: HomeClientProps) {
     }
     return map;
   }, [initialData.weekSchedules]);
+
+  // Keep html background in sync with theme so overscroll bounce area matches
+  useEffect(() => {
+    document.documentElement.style.backgroundColor =
+      mode === 'dark' ? '#0f172a' : '#f8fafc';
+  }, [mode]);
 
   // Set initial live statuses immediately
   useEffect(() => {
@@ -120,67 +127,60 @@ export default function HomeClient({ initialData }: HomeClientProps) {
     fetchBanners();
   }, [streamersEnabled, banners.length]);
 
-  // Grid scroll detection for banner hide/show - optimized with capture phase and hysteresis
-  useEffect(() => {
-    const handleScroll = (e: Event) => {
-      const target = e.target as HTMLElement;
-
-      // Only process scroll events originating from our schedule grid
-      if (target && target.getAttribute && target.getAttribute('data-schedule-grid')) {
-        const currentScrollY = target.scrollTop;
-
-        setBannerVisible(prev => {
-          if (currentScrollY > 20 && prev) {
-            // Only hide if content would still overflow after banner is removed.
-            // Prevents the loop: banner hides → content fits → scrollTop resets to 0 → banner shows → repeat.
-            const bannerHeight = bannerContainerRef.current?.offsetHeight ?? 0;
-            const wouldStillOverflow = target.scrollHeight > target.clientHeight + bannerHeight;
-            if (!wouldStillOverflow) return prev;
-            return false;
-          }
-          if (currentScrollY <= 5 && !prev) return true;
-          return prev;
-        });
-      }
-    };
-
-    // Use capture phase to catch non-bubbling scroll events from descendants
-    document.addEventListener('scroll', handleScroll, { capture: true, passive: true });
-
-    return () => {
-      document.removeEventListener('scroll', handleScroll, { capture: true });
-    };
-  }, []);
-
-  // Forward wheel events from anywhere on the page to the grid
+  // Two-phase scroll: banner slides off first, then grid scrolls.
+  // Fully DOM-driven (no React re-renders in the hot path).
   useEffect(() => {
     const handleWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return; // ignore horizontal
+
       const scheduleGrid = document.querySelector('[data-schedule-grid]') as HTMLElement;
       if (!scheduleGrid) return;
 
-      // Check if the event target is already inside the grid or its children
-      const target = e.target as HTMLElement;
-      if (scheduleGrid.contains(target)) {
-        // Let the grid handle its own scroll
-        return;
-      }
+      const inner = bannerContainerRef.current;
+      const bannerH = inner?.offsetHeight ?? 0;
+      const currentOffset = bannerOffsetRef.current;
+      const insideGrid = scheduleGrid.contains(e.target as HTMLElement);
 
-      // Check if we're scrolling vertically (deltaY)
-      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
-        // Prevent default page scroll
-        e.preventDefault();
-
-        // Forward the scroll to the grid
-        scheduleGrid.scrollTop += e.deltaY;
+      if (e.deltaY > 0) {
+        // ── Scrolling down ──
+        if (currentOffset < bannerH) {
+          // Phase 1: consume delta for banner; block grid scroll
+          e.preventDefault();
+          const newOffset = Math.min(currentOffset + e.deltaY, bannerH);
+          bannerOffsetRef.current = newOffset;
+          if (inner) {
+            inner.style.transform = `translateY(-${newOffset}px)`;
+            inner.style.marginBottom = `-${newOffset}px`;
+          }
+        } else if (!insideGrid) {
+          // Phase 2: banner gone, forward to grid
+          e.preventDefault();
+          scheduleGrid.scrollTop += e.deltaY;
+        }
+        // else: insideGrid + banner gone → native scroll handles it
+      } else {
+        // ── Scrolling up ──
+        if (scheduleGrid.scrollTop > 0) {
+          // Grid still scrolled — let it scroll up first
+          if (!insideGrid) {
+            e.preventDefault();
+            scheduleGrid.scrollTop += e.deltaY;
+          }
+        } else if (currentOffset > 0) {
+          // Grid at top — restore banner
+          e.preventDefault();
+          const newOffset = Math.max(currentOffset + e.deltaY, 0);
+          bannerOffsetRef.current = newOffset;
+          if (inner) {
+            inner.style.transform = `translateY(-${newOffset}px)`;
+            inner.style.marginBottom = `-${newOffset}px`;
+          }
+        }
       }
     };
 
-    // Add wheel event listener to the window
     window.addEventListener('wheel', handleWheel, { passive: false });
-
-    return () => {
-      window.removeEventListener('wheel', handleWheel);
-    };
+    return () => window.removeEventListener('wheel', handleWheel);
   }, []);
 
   // Derive flat lists for grid
@@ -392,82 +392,20 @@ export default function HomeClient({ initialData }: HomeClientProps) {
             minHeight: 0
           }}
         >
-          {/* CSS Keyframes for banner and grid animations */}
-          <Box
-            component="style"
-            dangerouslySetInnerHTML={{
-              __html: `
-                @keyframes bannerHide {
-                  from {
-                    transform: scaleY(1);
-                    opacity: 1;
-                    max-height: 200px;
-                  }
-                  to {
-                    transform: scaleY(0);
-                    opacity: 0;
-                    max-height: 0;
-                  }
-                }
-                @keyframes bannerShow {
-                  from {
-                    transform: scaleY(0);
-                    opacity: 0;
-                    max-height: 0;
-                  }
-                  to {
-                    transform: scaleY(1);
-                    opacity: 1;
-                    max-height: 200px;
-                  }
-                }
-                @media (max-width: 600px) {
-                  @keyframes bannerHide {
-                    from {
-                      transform: scaleY(1);
-                      opacity: 1;
-                      max-height: 132px;
-                    }
-                    to {
-                      transform: scaleY(0);
-                      opacity: 0;
-                      max-height: 0;
-                    }
-                  }
-                  @keyframes bannerShow {
-                    from {
-                      transform: scaleY(0);
-                      opacity: 0;
-                      max-height: 0;
-                    }
-                    to {
-                      transform: scaleY(1);
-                      opacity: 1;
-                      max-height: 132px;
-                    }
-                  }
-                }
-              `,
-            }}
-          />
-
-          {/* Banner Carousel - Always render when enabled, animate with keyframes */}
+          {/* Banner Carousel - slides off the top naturally as the grid scrolls (DOM-driven, no React re-render) */}
           {streamersEnabled && banners.length > 0 && (
-            <Box
-              ref={bannerContainerRef}
-              sx={{
-                position: 'relative',
-                pb: { xs: 1, sm: 0 }, // 12px bottom padding for mobile only
-                pt: { md: 2, lg: 2 }, // 16px top padding for desktop only
-                overflow: 'hidden',
-                transformOrigin: 'top',
-                animation: bannerVisible
-                  ? 'bannerShow 0.3s ease-in-out forwards'
-                  : 'bannerHide 0.3s ease-in-out forwards',
-                maxHeight: bannerVisible ? { xs: '132px', sm: '200px' } : '0',
-              }}
-            >
-              <BannerCarousel banners={banners} />
+            <Box ref={bannerOuterRef} sx={{ overflow: 'hidden' }}>
+              <Box
+                ref={bannerContainerRef}
+                sx={{
+                  position: 'relative',
+                  pb: { xs: 1, sm: 0 },
+                  pt: { md: 2, lg: 2 },
+                  willChange: 'transform',
+                }}
+              >
+                <BannerCarousel banners={banners} />
+              </Box>
             </Box>
           )}
 
@@ -477,9 +415,6 @@ export default function HomeClient({ initialData }: HomeClientProps) {
               flex: 1,
               minHeight: 0,
               backdropFilter: 'blur(8px)',
-              animation: bannerVisible
-                ? 'gridMoveDown 0.3s ease-in-out forwards'
-                : 'gridMoveUp 0.3s ease-in-out forwards',
               display: 'flex',
               flexDirection: 'column',
             }}

--- a/src/components/backoffice/ConflictResolutionDialog.tsx
+++ b/src/components/backoffice/ConflictResolutionDialog.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  Divider,
+  ToggleButtonGroup,
+  ToggleButton,
+  TextField,
+  Alert,
+  Chip,
+} from '@mui/material';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+
+export interface ConflictInfo {
+  channelId: number;
+  channelName: string;
+  programId: number;
+  programName: string;
+  scheduleId?: number;
+  dayOfWeek: string;
+  weekStartDate: string;
+  currentStartTime: string;
+  currentEndTime: string;
+  suggestedAction: 'reschedule' | 'cancel';
+  suggestedStartTime?: string;
+  suggestedEndTime?: string;
+  hasExistingOverride: boolean;
+  existingOverrideId?: string;
+}
+
+export interface ConflictResolution {
+  programId?: number;
+  scheduleId?: number;
+  channelId: number;
+  dayOfWeek: string;
+  weekStartDate: string;
+  action: 'cancel' | 'reschedule' | 'keep';
+  newStartTime?: string;
+  newEndTime?: string;
+}
+
+interface Props {
+  open: boolean;
+  conflicts: ConflictInfo[];
+  targetWeek: 'current' | 'next';
+  linkedProgramName: string;
+  linkedProgramNewStart?: string;
+  linkedProgramNewEnd?: string;
+  onClose: () => void;
+  onSubmit: (resolutions: ConflictResolution[]) => void;
+}
+
+type ActionType = 'keep' | 'cancel' | 'reschedule';
+
+interface ResolutionState {
+  action: ActionType;
+  newStartTime: string;
+  newEndTime: string;
+}
+
+function conflictKey(c: ConflictInfo): string {
+  return `${c.programId}_${c.scheduleId ?? 'prog'}_${c.dayOfWeek}`;
+}
+
+export default function ConflictResolutionDialog({
+  open,
+  conflicts,
+  targetWeek,
+  linkedProgramName,
+  linkedProgramNewStart,
+  linkedProgramNewEnd,
+  onClose,
+  onSubmit,
+}: Props) {
+  const [resolutions, setResolutions] = useState<Record<string, ResolutionState>>(() => {
+    const initial: Record<string, ResolutionState> = {};
+    conflicts.forEach((c) => {
+      initial[conflictKey(c)] = {
+        action: c.suggestedAction === 'cancel' ? 'cancel' : 'reschedule',
+        newStartTime: c.suggestedStartTime ?? c.currentStartTime,
+        newEndTime: c.suggestedEndTime ?? c.currentEndTime,
+      };
+    });
+    return initial;
+  });
+
+  // Re-init when conflicts change
+  React.useEffect(() => {
+    const initial: Record<string, ResolutionState> = {};
+    conflicts.forEach((c) => {
+      initial[conflictKey(c)] = {
+        action: c.suggestedAction === 'cancel' ? 'cancel' : 'reschedule',
+        newStartTime: c.suggestedStartTime ?? c.currentStartTime,
+        newEndTime: c.suggestedEndTime ?? c.currentEndTime,
+      };
+    });
+    setResolutions(initial);
+  }, [conflicts]);
+
+  const setAction = (key: string, action: ActionType) => {
+    setResolutions((prev) => ({ ...prev, [key]: { ...prev[key], action } }));
+  };
+
+  const setTime = (key: string, field: 'newStartTime' | 'newEndTime', value: string) => {
+    setResolutions((prev) => ({ ...prev, [key]: { ...prev[key], [field]: value } }));
+  };
+
+  const handleSubmit = () => {
+    const result: ConflictResolution[] = conflicts.map((c) => {
+      const key = conflictKey(c);
+      const res = resolutions[key];
+      return {
+        programId: c.programId,
+        scheduleId: c.scheduleId,
+        channelId: c.channelId,
+        dayOfWeek: c.dayOfWeek,
+        weekStartDate: c.weekStartDate,
+        action: res?.action ?? 'keep',
+        newStartTime: res?.action === 'reschedule' ? res.newStartTime : undefined,
+        newEndTime: res?.action === 'reschedule' ? res.newEndTime : undefined,
+      };
+    });
+    onSubmit(result);
+  };
+
+  // Group by channel
+  const byChannel: Record<number, { name: string; conflicts: ConflictInfo[] }> = {};
+  conflicts.forEach((c) => {
+    if (!byChannel[c.channelId]) {
+      byChannel[c.channelId] = { name: c.channelName, conflicts: [] };
+    }
+    byChannel[c.channelId].conflicts.push(c);
+  });
+
+  const weekLabel = targetWeek === 'current' ? 'esta semana' : 'la próxima semana';
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <WarningAmberIcon color="warning" />
+        Conflictos detectados
+      </DialogTitle>
+
+      <DialogContent>
+        <Alert severity="info" sx={{ mb: 2 }}>
+          {linkedProgramName}
+          {linkedProgramNewStart && linkedProgramNewEnd
+            ? ` fue reprogramado de ${linkedProgramNewStart} a ${linkedProgramNewEnd}`
+            : ' fue modificado'}{' '}
+          para {weekLabel}. Los programas a continuación se superponen con el nuevo horario.
+          Elegí qué hacer con cada uno.
+        </Alert>
+
+        {Object.entries(byChannel).map(([channelIdStr, { name, conflicts: channelConflicts }]) => (
+          <Box key={channelIdStr} sx={{ mb: 3 }}>
+            <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
+              {name}
+            </Typography>
+            <Divider sx={{ mb: 2 }} />
+
+            {channelConflicts.map((c) => {
+              const key = conflictKey(c);
+              const res = resolutions[key];
+
+              return (
+                <Box
+                  key={key}
+                  sx={{
+                    mb: 2,
+                    p: 2,
+                    border: '1px solid',
+                    borderColor: 'divider',
+                    borderRadius: 1,
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+                    <Typography fontWeight="medium">{c.programName}</Typography>
+                    <Chip
+                      label={`${c.currentStartTime} – ${c.currentEndTime}`}
+                      size="small"
+                      variant="outlined"
+                    />
+                    {c.hasExistingOverride && (
+                      <Chip label="ya tiene override" size="small" color="warning" />
+                    )}
+                  </Box>
+
+                  <ToggleButtonGroup
+                    value={res?.action ?? 'keep'}
+                    exclusive
+                    onChange={(_, val) => val && setAction(key, val as ActionType)}
+                    size="small"
+                    sx={{ mb: 1 }}
+                  >
+                    <ToggleButton value="keep">Dejar como está</ToggleButton>
+                    <ToggleButton value="reschedule">Ajustar horario</ToggleButton>
+                    <ToggleButton value="cancel">Cancelar</ToggleButton>
+                  </ToggleButtonGroup>
+
+                  {res?.action === 'reschedule' && (
+                    <Box sx={{ display: 'flex', gap: 2, mt: 1 }}>
+                      <TextField
+                        label="Nuevo inicio"
+                        type="time"
+                        value={res.newStartTime}
+                        onChange={(e) => setTime(key, 'newStartTime', e.target.value)}
+                        size="small"
+                        InputLabelProps={{ shrink: true }}
+                      />
+                      <TextField
+                        label="Nuevo fin"
+                        type="time"
+                        value={res.newEndTime}
+                        onChange={(e) => setTime(key, 'newEndTime', e.target.value)}
+                        size="small"
+                        InputLabelProps={{ shrink: true }}
+                      />
+                    </Box>
+                  )}
+                </Box>
+              );
+            })}
+          </Box>
+        ))}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Omitir todo</Button>
+        <Button onClick={handleSubmit} variant="contained">
+          Aplicar resoluciones
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -56,6 +56,10 @@ import type { WeeklyOverride } from '@/types/schedule';
 import type { Program } from '@/types/program';
 import type { Panelist } from '@/types/panelist';
 import { useTheme } from '@mui/material/styles';
+import ConflictResolutionDialog, {
+  type ConflictInfo,
+  type ConflictResolution,
+} from './ConflictResolutionDialog';
 
 // Types
 interface WeeklyStats {
@@ -132,6 +136,14 @@ export function WeeklyOverridesTable() {
   // Multi-select & bulk delete for special programs
   const [selectedOverrideIds, setSelectedOverrideIds] = useState<Set<string>>(new Set());
   const [confirmBulkOverrideDeleteOpen, setConfirmBulkOverrideDeleteOpen] = useState(false);
+
+  // Conflict resolution dialog
+  const [conflictDialogOpen, setConflictDialogOpen] = useState(false);
+  const [pendingConflicts, setPendingConflicts] = useState<ConflictInfo[]>([]);
+  const [conflictLinkedName, setConflictLinkedName] = useState('');
+  const [conflictLinkedNewStart, setConflictLinkedNewStart] = useState<string | undefined>();
+  const [conflictLinkedNewEnd, setConflictLinkedNewEnd] = useState<string | undefined>();
+  const [conflictTargetWeek, setConflictTargetWeek] = useState<'current' | 'next'>('current');
 
   // Fetch data
   const fetchData = useCallback(async () => {
@@ -330,9 +342,22 @@ export function WeeklyOverridesTable() {
           const errorData = await response.json();
           throw new Error(errorData.message || 'Error al crear los programas especiales');
         }
+        const capturedSpecialName = formData.specialProgram.name;
+        const capturedNewStart = formData.newStartTime;
+        const capturedNewEnd = formData.newEndTime;
+        const capturedTargetWeek = formData.targetWeek;
+        const bulkResponseData = await response.json().catch(() => ({}));
         setSuccess(`${specialChannelIds.length} programas especiales creados correctamente`);
         handleCloseDialog();
         await fetchData();
+        if (bulkResponseData.conflicts && bulkResponseData.conflicts.length > 0) {
+          setPendingConflicts(bulkResponseData.conflicts);
+          setConflictLinkedName(capturedSpecialName);
+          setConflictLinkedNewStart(capturedNewStart || undefined);
+          setConflictLinkedNewEnd(capturedNewEnd || undefined);
+          setConflictTargetWeek(capturedTargetWeek);
+          setConflictDialogOpen(true);
+        }
         return;
       }
 
@@ -416,12 +441,59 @@ export function WeeklyOverridesTable() {
         throw new Error(errorData.message || `Error al ${isEditMode ? 'actualizar' : 'crear'} el cambio`);
       }
 
+      // Capture context before closing (state resets on close)
+      const linkedName = isEditMode && editingOverride
+        ? schedules.find(s => s.id === editingOverride.scheduleId)?.program?.name
+          || programs.find(p => p.id === editingOverride.programId)?.name
+          || 'Programa'
+        : selectedSchedule?.program?.name || selectedProgram?.name || 'Programa';
+      const capturedNewStart = formData.newStartTime;
+      const capturedNewEnd = formData.newEndTime;
+      const capturedTargetWeek = formData.targetWeek;
+
+      const responseData = await response.json().catch(() => ({}));
+
       setSuccess(`Cambio semanal ${isEditMode ? 'actualizado' : 'creado'} correctamente`);
       handleCloseDialog();
       await fetchData();
+
+      if (responseData.conflicts && responseData.conflicts.length > 0) {
+        setPendingConflicts(responseData.conflicts);
+        setConflictLinkedName(linkedName);
+        setConflictLinkedNewStart(capturedNewStart || undefined);
+        setConflictLinkedNewEnd(capturedNewEnd || undefined);
+        setConflictTargetWeek(capturedTargetWeek);
+        setConflictDialogOpen(true);
+      }
     } catch (err) {
       console.error('Error creating override:', err);
       setError(err instanceof Error ? err.message : 'Error al crear el cambio');
+    }
+  };
+
+  const handleConflictSubmit = async (resolutions: ConflictResolution[]) => {
+    const activeResolutions = resolutions.filter((r) => r.action !== 'keep');
+    setConflictDialogOpen(false);
+    setPendingConflicts([]);
+    if (activeResolutions.length === 0) return;
+    try {
+      const response = await fetch('/api/weekly-overrides/resolve-conflicts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${typedSession?.accessToken}`,
+        },
+        body: JSON.stringify({
+          targetWeek: conflictTargetWeek,
+          resolutions: activeResolutions,
+        }),
+      });
+      if (!response.ok) throw new Error('Error al resolver conflictos');
+      const data = await response.json();
+      setSuccess(`Conflictos resueltos: ${data.resolved} modificación(es) aplicada(s)`);
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al resolver conflictos');
     }
   };
 
@@ -749,7 +821,10 @@ export function WeeklyOverridesTable() {
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {override.overrideType === 'create'
-                          ? `Canal ID: ${override.specialProgram?.channelId || 'N/A'}`
+                          ? override.specialProgram?.channel?.name
+                            || channels.find(c => c.id === override.specialProgram?.channelId)?.name
+                            || override.specialProgram?.channelId?.toString()
+                            || 'Sin canal'
                           : program?.channel_name || schedule?.program.channel?.name || 'Sin canal'
                         }
                       </Typography>
@@ -867,7 +942,10 @@ export function WeeklyOverridesTable() {
                       </Typography>
                       <Typography variant="caption" color="text.secondary">
                         {override.overrideType === 'create'
-                          ? `Canal ID: ${override.specialProgram?.channelId || 'N/A'}`
+                          ? override.specialProgram?.channel?.name
+                            || channels.find(c => c.id === override.specialProgram?.channelId)?.name
+                            || override.specialProgram?.channelId?.toString()
+                            || 'Sin canal'
                           : program?.channel_name || schedule?.program.channel?.name || 'Sin canal'
                         }
                       </Typography>
@@ -1291,7 +1369,10 @@ export function WeeklyOverridesTable() {
                         </TableCell>
                         <TableCell>
                           <Typography variant="body2">
-                            Canal ID: {override.specialProgram?.channelId || 'N/A'}
+                            {override.specialProgram?.channel?.name
+                              || channels.find(c => c.id === override.specialProgram?.channelId)?.name
+                              || override.specialProgram?.channelId?.toString()
+                              || 'Sin canal'}
                           </Typography>
                         </TableCell>
                         <TableCell>
@@ -1857,6 +1938,18 @@ export function WeeklyOverridesTable() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      {/* Conflict resolution dialog */}
+      <ConflictResolutionDialog
+        open={conflictDialogOpen}
+        conflicts={pendingConflicts}
+        targetWeek={conflictTargetWeek}
+        linkedProgramName={conflictLinkedName}
+        linkedProgramNewStart={conflictLinkedNewStart}
+        linkedProgramNewEnd={conflictLinkedNewEnd}
+        onClose={() => { setConflictDialogOpen(false); setPendingConflicts([]); }}
+        onSubmit={handleConflictSubmit}
+      />
     </Box>
   );
 } 

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -16,4 +16,5 @@ export interface Program {
   style_override?: string | null;
   is_visible?: boolean;
   is_premiere?: boolean;
+  link_group_id?: string | null;
 }

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -54,5 +54,6 @@ export interface WeeklyOverride {
     imageUrl?: string;
     stream_url?: string;
     is_premiere?: boolean;
+    channel?: { id: number; name: string; [key: string]: unknown };
   };
 }


### PR DESCRIPTION
## [1.26.0] - 2026-06-23

### Added

- **Creación de programas en múltiples canales**: el selector de canal en el formulario de nuevo programa es ahora un `Autocomplete` multi-select. Con 2+ canales seleccionados se llama a `POST /api/programs/bulk` y se crean N programas independientes en una sola acción.
- **Creación de programas especiales en múltiples canales**: el selector de canal en el tab "Programas Especiales" también es multi-select; con 2+ canales se llama a `POST /api/weekly-overrides/bulk`.
- **Borrado masivo de programas**: la columna "Logo" (sin uso) fue reemplazada por una columna de checkbox. Al seleccionar ≥1 programa aparece una barra flotante con la opción de eliminar, con diálogo de confirmación que lista `nombre — canal` de cada programa.
- **Borrado masivo de cambios semanales**: misma mecánica de checkbox + barra flotante + diálogo de confirmación en los tabs "Semana Actual", "Próxima Semana" y "Programas Especiales". La selección se limpia automáticamente al cambiar de tab.
- **Programas linkeados — UI de backoffice**: ícono de vínculo en la tabla de programas cuando un programa tiene `link_group_id`. Diálogo de confirmación de borrado advierte que eliminar un programa linkeado no afecta al resto del grupo.
- **Diálogo de resolución de conflictos** (`ConflictResolutionDialog`): tras crear o editar un weekly override, si el backend detecta solapamientos en la grilla se muestra automáticamente un diálogo que lista cada conflicto agrupado por canal, con sugerencia automática de acción (ajustar horario o cancelar) y pickers de tiempo editables. Las resoluciones se envían a `POST /api/weekly-overrides/resolve-conflicts`.

### Fixed

- El tab "Programas Especiales" de weekly overrides ahora muestra el nombre del canal en vez del ID numérico para overrides de tipo `create`.
- **Banner web — scroll en dos fases**: el banner ahora se desplaza hacia arriba y desaparece completamente antes de que la grilla empiece a moverse, replicando el comportamiento de la app nativa. El offset del banner se actualiza mediante mutación directa del DOM (sin re-renders de React) para evitar fricción en el scroll.
- Fondo del área de over-scroll (bounce) ahora coincide con el color de fondo del tema (oscuro `#0f172a` / claro `#f8fafc`) en lugar de mostrar blanco.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)