### PR TITLE
🎨 Palette: Improve accessibility of auth back buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2025-02-18 - Missing ARIA labels on Multi-Step Navigation Buttons
+**Learning:** Found a recurring accessibility pattern in multi-step authentication flows where the "Volver" (Back) buttons were missing `aria-label` attributes. While the button text "Volver" is present, an explicit `aria-label="Volver al paso anterior"` provides clearer context for screen reader users navigating complex, stateful multi-step forms.
+**Action:** When implementing wizard-like or multi-step flows, ensure that secondary navigation buttons like "Back" or "Previous" have explicit `aria-label` attributes detailing their specific context.

--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -187,6 +187,7 @@ export default function CodeStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -131,6 +131,7 @@ export default function ExistingUserStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -154,6 +154,7 @@ export default function PasswordStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -171,6 +171,7 @@ export default function ProfileStep({
             startIcon={<ArrowBackIosNewIcon fontSize="small" />}
             fullWidth
             onClick={onBack}
+            aria-label="Volver al paso anterior"
           >
             Volver
           </Button>


### PR DESCRIPTION
💡 **What:** Added explicit `aria-label="Volver al paso anterior"` attributes to the "Volver" (Back) buttons across all authentication steps (Password, Code, Existing User, Profile).

🎯 **Why:** To improve accessibility for screen reader users navigating the multi-step authentication flow. While the button text says "Volver", an explicit label provides clearer context about what state is being navigated.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Screen readers will now announce "Volver al paso anterior, botón" instead of just "Volver, botón", reducing ambiguity in stateful wizard flows.

---
*PR created automatically by Jules for task [16220160638348621423](https://jules.google.com/task/16220160638348621423) started by @matiasrozenblum*