### PR TITLE
feat: inactive program badge in favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 
+## [1.27.0] - 2026-06-26
+
+### Added
+
+- **Distinción visual de programas inactivos en Mis favoritos**: los programas suscriptos que tienen `is_visible=false` o sin horarios activos ahora se muestran en escala de grises (logo + fondo) con opacidad reducida y un chip "Sin emisión" con ícono de pausa. Los programas inactivos se ordenan al final de la lista. La suscripción se conserva para que se reactive automáticamente si el programa vuelve a emitir.
+
+---
+
 ## [1.26.0] - 2026-06-23
 
 ### Added

--- a/src/components/SubscriptionsClient.tsx
+++ b/src/components/SubscriptionsClient.tsx
@@ -166,7 +166,9 @@ const SubscriptionTile = ({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          position: 'relative'
+          position: 'relative',
+          filter: isInactive ? 'grayscale(1)' : 'none',
+          transition: 'filter 0.2s',
         }}
       >
         {imageUrl ? (
@@ -179,8 +181,6 @@ const SubscriptionTile = ({
               height: '100%',
               objectFit: isStreamer ? 'cover' : 'contain',
               p: isStreamer ? 0 : 0.5,
-              filter: isInactive ? 'grayscale(1)' : 'none',
-              transition: 'filter 0.2s',
             }}
           />
         ) : (

--- a/src/components/SubscriptionsClient.tsx
+++ b/src/components/SubscriptionsClient.tsx
@@ -12,9 +12,11 @@ import {
   Tooltip,
   Alert,
   CircularProgress,
+  Chip,
 } from '@mui/material';
 import {
   ArrowBack,
+  PauseCircle,
 } from '@mui/icons-material';
 import { Streamer, StreamingService } from '@/types/streamer';
 
@@ -70,6 +72,9 @@ export interface UserSubscription {
     name: string;
     description?: string;
     logoUrl?: string;
+    logo_url?: string;
+    is_visible: boolean;
+    has_active_schedules: boolean;
     channel: {
       id: number;
       name: string;
@@ -90,6 +95,7 @@ const SubscriptionTile = ({
   imageUrl,
   imageColor,
   isStreamer,
+  isInactive,
   activeDeleteId,
   onToggleDelete,
   onDelete,
@@ -104,6 +110,7 @@ const SubscriptionTile = ({
   imageUrl?: string,
   imageColor?: string,
   isStreamer?: boolean,
+  isInactive?: boolean,
   activeDeleteId: string | number | null,
   onToggleDelete: (id: string | number) => void,
   onDelete: (e: React.MouseEvent) => void,
@@ -128,16 +135,17 @@ const SubscriptionTile = ({
         if (showDelete) onToggleDelete(id);
       }}
       sx={{
-        height: 80, // Compact fixed height
+        height: 80,
         display: 'flex',
         alignItems: 'center',
-        background: mode === 'light' ? '#ffffff' : '#1e293b', // Darker surface
+        background: mode === 'light' ? '#ffffff' : '#1e293b',
         borderRadius: 2,
         border: mode === 'light' ? '1px solid #e2e8f0' : '1px solid #334155',
         overflow: 'hidden',
         cursor: 'pointer',
         position: 'relative',
         transition: 'all 0.2s',
+        opacity: isInactive ? 0.6 : 1,
         '@media (hover: hover) and (pointer: fine)': {
           '&:hover .delete-btn': { opacity: '1 !important' }
         },
@@ -169,8 +177,10 @@ const SubscriptionTile = ({
             sx={{
               width: '100%',
               height: '100%',
-              objectFit: isStreamer ? 'cover' : 'contain', // Streamers use cover, Programs use contain
-              p: isStreamer ? 0 : 0.5 // Streamers have no padding, channels have 4px padding
+              objectFit: isStreamer ? 'cover' : 'contain',
+              p: isStreamer ? 0 : 0.5,
+              filter: isInactive ? 'grayscale(1)' : 'none',
+              transition: 'filter 0.2s',
             }}
           />
         ) : (
@@ -192,6 +202,23 @@ const SubscriptionTile = ({
           <Box display="flex" alignItems="center" gap={1} overflow="hidden">
             {subtitle}
           </Box>
+        )}
+
+        {isInactive && (
+          <Chip
+            icon={<PauseCircle />}
+            label="Sin emisión"
+            size="small"
+            sx={{
+              height: 17,
+              alignSelf: 'flex-start',
+              bgcolor: mode === 'light' ? 'rgba(0,0,0,0.06)' : 'rgba(255,255,255,0.07)',
+              color: 'text.disabled',
+              border: 'none',
+              '& .MuiChip-icon': { fontSize: '0.7rem', color: 'text.disabled', ml: 0.5 },
+              '& .MuiChip-label': { px: 0.75, fontSize: '0.65rem', fontWeight: 500 },
+            }}
+          />
         )}
 
         {/* Small Service Icons for Streamers */}
@@ -506,25 +533,37 @@ export default function SubscriptionsClient({ initialSubscriptions, initialStrea
                     >
                       {subscriptions.length > 0 ? (
                         <Grid container spacing={2}>
-                          {subscriptions.map((subscription) => (
-                            <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={subscription.id}>
-                              <SubscriptionTile
-                                id={subscription.id}
-                                activeDeleteId={activeDeleteId}
-                                onToggleDelete={(id) => setActiveDeleteId(activeDeleteId === id ? null : id)}
-                                title={subscription.program.name}
-                                subtitle={
-                                  <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.85rem' }}>
-                                    en <Box component="span" fontWeight={600} color="text.primary">{subscription.program.channel.name.toUpperCase()}</Box>
-                                  </Typography>
-                                }
-                                imageUrl={subscription.program.channel.logo_url}
-                                imageColor={subscription.program.channel.background_color || '#ffffff'}
-                                onDelete={(e) => { e.stopPropagation(); removeSubscription(subscription.id); }}
-                                deleteTooltip="Cancelar suscripción"
-                              />
-                            </Grid>
-                          ))}
+                          {[...subscriptions]
+                            .sort((a, b) => {
+                              const aInactive = !a.program.is_visible || !a.program.has_active_schedules;
+                              const bInactive = !b.program.is_visible || !b.program.has_active_schedules;
+                              if (aInactive && !bInactive) return 1;
+                              if (!aInactive && bInactive) return -1;
+                              return 0;
+                            })
+                            .map((subscription) => {
+                              const isInactive = !subscription.program.is_visible || !subscription.program.has_active_schedules;
+                              return (
+                                <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={subscription.id}>
+                                  <SubscriptionTile
+                                    id={subscription.id}
+                                    activeDeleteId={activeDeleteId}
+                                    onToggleDelete={(id) => setActiveDeleteId(activeDeleteId === id ? null : id)}
+                                    title={subscription.program.name}
+                                    isInactive={isInactive}
+                                    subtitle={
+                                      <Typography variant="body2" color="text.secondary" sx={{ fontSize: '0.85rem' }}>
+                                        en <Box component="span" fontWeight={600} color="text.primary">{subscription.program.channel.name.toUpperCase()}</Box>
+                                      </Typography>
+                                    }
+                                    imageUrl={subscription.program.channel.logo_url}
+                                    imageColor={subscription.program.channel.background_color || '#ffffff'}
+                                    onDelete={(e) => { e.stopPropagation(); removeSubscription(subscription.id); }}
+                                    deleteTooltip="Cancelar suscripción"
+                                  />
+                                </Grid>
+                              );
+                            })}
                         </Grid>
                       ) : (
                         <Typography variant="body2" color="text.secondary" sx={{ px: 1 }}>No tienes suscripciones a programas.</Typography>


### PR DESCRIPTION
## Summary

- Programas suscriptos con `is_visible=false` o sin horarios activos se muestran en escala de grises (logo + fondo de canal) con opacidad reducida y un chip **"Sin emisión"** con ícono de pausa
- Los programas inactivos se ordenan al final de la lista (activos primero)
- La suscripción se conserva intacta para reactivarse automáticamente si el programa vuelve

## Cambios

- `SubscriptionsClient.tsx`: nuevos campos `is_visible` + `has_active_schedules` en el tipo `UserSubscription`, prop `isInactive` en `SubscriptionTile`, sort activos/inactivos, estilos grayscale + opacity + chip MUI
- Requiere backend `>=` commit que agrega `is_visible` y `has_active_schedules` al endpoint `GET /subscriptions` (ya deployado a staging)

## Test plan

- [ ] Validar en staging que programas inactivos aparecen griseados con chip "Sin emisión"
- [ ] Confirmar que programas activos no se ven afectados
- [ ] Verificar orden: activos primero, inactivos al final
- [ ] Comprobar que la suscripción se puede eliminar normalmente desde el card inactivo
- [ ] Revisar en light mode y dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)