### PR TITLE
Release 1.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 
+## [1.27.1] - 2026-06-27
+
+### Fixed
+
+- **Backoffice weekly overrides — semana objetivo incorrecta al editar**: al abrir el diálogo de edición después de las 21 hs (AR, UTC-3), `getWeekStartDate` devolvía la fecha incorrecta porque `toISOString()` convertía a UTC y cruzaba al día siguiente. Se reemplazó por partes locales (`getFullYear/getMonth/getDate`). Adicionalmente la comparación usa `substring(0, 10)` para tolerancia de formatos con timestamp.
+- **Backoffice weekly overrides — 404 al editar/eliminar programas linkeados**: los IDs de programas linkeados con `/` en el nombre (e.g. "GHANA / PANAMÁ") rompían el routing URL. Se reemplazó la ruta API `[id]` por un catch-all `[...id]` que reconstruye el ID con los segmentos, y se usa `encodeURIComponent` al llamar al backend para que Express los trate como un único parámetro.
+
+---
+
 ## [1.27.0] - 2026-06-26
 
 ### Added

--- a/src/app/api/weekly-overrides/[...id]/route.ts
+++ b/src/app/api/weekly-overrides/[...id]/route.ts
@@ -3,19 +3,20 @@ import { requireAccessToken } from '@/utils/auth-server';
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string[] }> }
 ) {
   try {
     const token = await requireAccessToken(request);
-    
+
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const { id } = await params;
+    const overrideId = id.join('/');
     const body = await request.json();
-    
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/weekly-overrides/${id}`, {
+
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/weekly-overrides/${encodeURIComponent(overrideId)}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -42,17 +43,18 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string[] }> }
 ) {
   try {
     const token = await requireAccessToken(request);
-    
+
     if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const { id } = await params;
-    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/weekly-overrides/${id}`, {
+    const overrideId = id.join('/');
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/weekly-overrides/${encodeURIComponent(overrideId)}`, {
       method: 'DELETE',
       headers: {
         'Authorization': `Bearer ${token}`,
@@ -75,4 +77,4 @@ export async function DELETE(
     console.error('Error deleting weekly override:', error);
     return NextResponse.json({ error: 'Failed to delete weekly override' }, { status: 500 });
   }
-} 
+}

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -422,7 +422,7 @@ export function WeeklyOverridesTable() {
       };
 
       const url = isEditMode && editingOverride
-        ? `/api/weekly-overrides/${editingOverride.id}`
+        ? `/api/weekly-overrides/${encodeURIComponent(editingOverride.id)}`
         : '/api/weekly-overrides';
 
       const method = isEditMode ? 'PUT' : 'POST';
@@ -501,7 +501,7 @@ export function WeeklyOverridesTable() {
     if (!confirm('¿Estás seguro de que deseas eliminar este cambio?')) return;
 
     try {
-      const response = await fetch(`/api/weekly-overrides/${overrideId}`, {
+      const response = await fetch(`/api/weekly-overrides/${encodeURIComponent(overrideId)}`, {
         method: 'DELETE',
         headers: { Authorization: `Bearer ${typedSession?.accessToken}` },
       });
@@ -524,7 +524,7 @@ export function WeeklyOverridesTable() {
     
     // Populate form with existing data
     setFormData({
-      targetWeek: override.weekStartDate === getWeekStartDate('current') ? 'current' : 'next',
+      targetWeek: override.weekStartDate.substring(0, 10) === getWeekStartDate('current') ? 'current' : 'next',
       overrideType: override.overrideType,
       newStartTime: override.newStartTime || '',
       newEndTime: override.newEndTime || '',
@@ -635,7 +635,7 @@ export function WeeklyOverridesTable() {
     try {
       await Promise.all(
         [...selectedOverrideIds].map(id =>
-          fetch(`/api/weekly-overrides/${id}`, {
+          fetch(`/api/weekly-overrides/${encodeURIComponent(id)}`, {
             method: 'DELETE',
             headers: { Authorization: `Bearer ${typedSession?.accessToken}` },
           }),
@@ -675,17 +675,16 @@ export function WeeklyOverridesTable() {
   const getWeekStartDate = (targetWeek: 'current' | 'next'): string => {
     const now = new Date();
     const currentDay = now.getDay();
-    const daysToMonday = currentDay === 0 ? 6 : currentDay - 1; // Sunday = 0, Monday = 1
-    
-    if (targetWeek === 'current') {
-      const monday = new Date(now);
-      monday.setDate(now.getDate() - daysToMonday);
-      return monday.toISOString().split('T')[0];
-    } else {
-      const nextMonday = new Date(now);
-      nextMonday.setDate(now.getDate() - daysToMonday + 7);
-      return nextMonday.toISOString().split('T')[0];
-    }
+    const daysToMonday = currentDay === 0 ? 6 : currentDay - 1;
+
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - daysToMonday + (targetWeek === 'next' ? 7 : 0));
+
+    // Use local date parts to avoid UTC offset shifting the date (e.g. AR is UTC-3)
+    const year = monday.getFullYear();
+    const month = String(monday.getMonth() + 1).padStart(2, '0');
+    const day = String(monday.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
   };
 
   const getDayLabel = (day: string) => {


### PR DESCRIPTION
## [1.27.1] - 2026-06-27

### Fixed

- **Backoffice weekly overrides — semana objetivo incorrecta al editar**: al abrir el diálogo de edición después de las 21 hs (AR, UTC-3), `getWeekStartDate` devolvía la fecha incorrecta porque `toISOString()` convertía a UTC y cruzaba al día siguiente. Se reemplazó por partes locales (`getFullYear/getMonth/getDate`). Adicionalmente la comparación usa `substring(0, 10)` para tolerancia de formatos con timestamp.
- **Backoffice weekly overrides — 404 al editar/eliminar programas linkeados**: los IDs de programas linkeados con `/` en el nombre (e.g. "GHANA / PANAMÁ") rompían el routing URL. Se reemplazó la ruta API `[id]` por un catch-all `[...id]` que reconstruye el ID con los segmentos, y se usa `encodeURIComponent` al llamar al backend para que Express los trate como un único parámetro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)