### PR TITLE
🎨 Palette: Add contextual aria-labels to 'Volver' buttons in auth flow

### DIFF
--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -187,6 +187,7 @@ export default function CodeStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -131,6 +131,7 @@ export default function ExistingUserStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -154,6 +154,7 @@ export default function PasswordStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -171,6 +171,7 @@ export default function ProfileStep({
             startIcon={<ArrowBackIosNewIcon fontSize="small" />}
             fullWidth
             onClick={onBack}
+            aria-label="Volver al paso anterior"
           >
             Volver
           </Button>


### PR DESCRIPTION
### What
Added `aria-label="Volver al paso anterior"` to the "Volver" (Back) buttons across the authentication flow steps (`CodeStep`, `ExistingUserStep`, `PasswordStep`, and `ProfileStep`).

### Why
Screen reader users navigating through multi-step forms or modals encounter buttons simply labeled "Volver" (Return). Without visual context, it may not be immediately clear *where* they are returning to. By providing a contextual `aria-label`, we clearly communicate that the action will return them to the previous step in the flow.

### Before/After
* **Before:** `<Button ...>Volver</Button>` (Screen reader announces: "Volver, botón")
* **After:** `<Button aria-label="Volver al paso anterior" ...>Volver</Button>` (Screen reader announces: "Volver al paso anterior, botón")

### Accessibility
This change directly improves the experience for users relying on assistive technologies by providing necessary context for navigation actions within complex flows, adhering to WCAG guidelines for clear and descriptive labels (WCAG 2.4.6, 2.5.3).

---
*PR created automatically by Jules for task [16506347964769218871](https://jules.google.com/task/16506347964769218871) started by @matiasrozenblum*