### PR TITLE
Release 1.27.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 
+## [1.27.2] - 2026-06-28
+
+### Changed
+
+- **Backoffice — limpieza de campos no utilizados en dialogs**: se eliminaron del formulario de programas los campos `logo_url` y `style_override` (incluyendo la columna "Estilo especial" de la tabla), del formulario de panelistas el campo `avatar_url` (incluyendo la columna "Avatar" de la tabla), y del formulario de weekly overrides el campo `motivo` (incluyendo la columna "Motivo" de ambas tablas). Estos campos permanecen en la DB y el backend, simplemente dejan de mostrarse/enviarse desde la UI.
+- **Backoffice — feedback visual al guardar**: los botones de submit de los dialogs de programas, panelistas y weekly overrides ahora muestran un spinner interno (`CircularProgress`) y se deshabilitan mientras la petición está en curso, evitando dobles envíos. El botón mantiene su tamaño original durante el estado de carga (spinner superpuesto con `position: absolute`, texto oculto con `visibility: hidden`).
+- **Backoffice — logo duplicado en sidebar**: se eliminó la imagen `logo.png` redundante del sidebar; la imagen `text-white.png` / `text.png` ya incluye el logo y el texto juntos.
+
+### Fixed
+
+- **Backoffice programas — confirmación antes de eliminar**: el botón de eliminar (trash) en la tabla de programas ahora muestra un diálogo de confirmación con el nombre del programa y el canal al que pertenece, con opciones de confirmar o cancelar, antes de proceder con el borrado.
+
+---
+
 ## [1.27.1] - 2026-06-27
 
 ### Fixed

--- a/src/app/backoffice/layout.tsx
+++ b/src/app/backoffice/layout.tsx
@@ -80,14 +80,6 @@ export default function BackofficeLayout({ children }: { children: React.ReactNo
         >
           <Image
             unoptimized
-            src="/img/logo.png"
-            alt="La Guía del Streaming"
-            width={44}
-            height={44}
-            style={{ marginRight: '8px', objectFit: 'contain' }}
-          />
-          <Image
-            unoptimized
             src={mode === 'light' ? '/img/text.png' : '/img/text-white.png'}
             alt="La Guía del Streaming"
             width={120}

--- a/src/app/backoffice/programs/page.tsx
+++ b/src/app/backoffice/programs/page.tsx
@@ -78,12 +78,11 @@ export default function ProgramsPage() {
     description: '',
     channel_id: '',       // used when editing an existing program
     channel_ids: [] as string[], // used when creating (supports multi-select)
-    logo_url: '',
     youtube_url: '',
-    style_override: '',
     is_visible: true,
     is_premiere: false,
   });
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [openPanelistsDialog, setOpenPanelistsDialog] = useState(false);
@@ -93,6 +92,9 @@ export default function ProgramsPage() {
   // Multi-select & bulk delete
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
   const [confirmBulkDeleteOpen, setConfirmBulkDeleteOpen] = useState(false);
+
+  // Single-program delete confirmation dialog
+  const [confirmDeleteDialog, setConfirmDeleteDialog] = useState<{ open: boolean; program: Program | null }>({ open: false, program: null });
 
   // Linked-program delete dialog
   const [linkedDeleteDialog, setLinkedDeleteDialog] = useState<{ open: boolean; program: Program | null }>({ open: false, program: null });
@@ -214,9 +216,7 @@ export default function ProgramsPage() {
         description: program.description || '',
         channel_id: String(program.channel_id),
         channel_ids: [],
-        logo_url: program.logo_url || '',
         youtube_url: program.youtube_url || '',
-        style_override: program.style_override || '',
         is_visible: program.is_visible ?? true,
         is_premiere: program.is_premiere ?? false,
       });
@@ -227,9 +227,7 @@ export default function ProgramsPage() {
         description: '',
         channel_id: '',
         channel_ids: [],
-        logo_url: '',
         youtube_url: '',
-        style_override: '',
         is_visible: true,
         is_premiere: false,
       });
@@ -245,9 +243,7 @@ export default function ProgramsPage() {
       description: '',
       channel_id: '',
       channel_ids: [],
-      logo_url: '',
       youtube_url: '',
-      style_override: '',
       is_visible: true,
       is_premiere: false,
     });
@@ -257,6 +253,7 @@ export default function ProgramsPage() {
 
   const handleSubmit = async () => {
     try {
+      setIsSubmitting(true);
       if (editingProgram) {
         // Edit existing program — single channel, same as before
         const res = await fetch(`/api/programs/${editingProgram.id}`, {
@@ -266,9 +263,7 @@ export default function ProgramsPage() {
             name: formData.name,
             description: formData.description,
             channel_id: parseInt(formData.channel_id),
-            logo_url: formData.logo_url,
             youtube_url: formData.youtube_url,
-            style_override: formData.style_override || null,
             is_visible: formData.is_visible,
             is_premiere: formData.is_premiere,
           }),
@@ -293,9 +288,7 @@ export default function ProgramsPage() {
             name: formData.name,
             description: formData.description,
             channel_ids: formData.channel_ids.map(Number),
-            logo_url: formData.logo_url,
             youtube_url: formData.youtube_url,
-            style_override: formData.style_override || null,
             is_visible: formData.is_visible,
             is_premiere: formData.is_premiere,
             ...(scheduleItems.length > 0 && { schedules: scheduleItems }),
@@ -317,9 +310,7 @@ export default function ProgramsPage() {
             name: formData.name,
             description: formData.description,
             channel_id: channelId,
-            logo_url: formData.logo_url,
             youtube_url: formData.youtube_url,
-            style_override: formData.style_override || null,
             is_visible: formData.is_visible,
             is_premiere: formData.is_premiere,
           }),
@@ -394,6 +385,8 @@ export default function ProgramsPage() {
     } catch (err: unknown) {
       console.error('Error saving program:', err);
       setError(err instanceof Error ? err.message : 'Error al guardar el programa');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -401,7 +394,7 @@ export default function ProgramsPage() {
     if (program.link_group_id) {
       setLinkedDeleteDialog({ open: true, program });
     } else {
-      handleDeleteConfirmed(program.id, false);
+      setConfirmDeleteDialog({ open: true, program });
     }
   };
 
@@ -563,7 +556,6 @@ export default function ProgramsPage() {
               <TableCell>Nombre</TableCell>
               <TableCell>Canal</TableCell>
               <TableCell>YouTube</TableCell>
-              <TableCell>Estilo especial</TableCell>
               <TableCell>Acciones</TableCell>
             </TableRow>
           </TableHead>
@@ -617,7 +609,6 @@ export default function ProgramsPage() {
                       'Sin enlace'
                     )}
                   </TableCell>
-                  <TableCell>{program.style_override || '-'}</TableCell>
                   <TableCell>
                     <Tooltip title="Editar programa" arrow>
                       <IconButton aria-label="Editar programa" onClick={() => handleOpenDialog(program)}><EditIcon /></IconButton>
@@ -706,9 +697,7 @@ export default function ProgramsPage() {
                 )}
               </Box>
             )}
-            <TextField label="URL del logo" value={formData.logo_url} onChange={e => setFormData({ ...formData, logo_url: e.target.value })} fullWidth />
             <TextField label="URL de YouTube" value={formData.youtube_url} onChange={e => setFormData({ ...formData, youtube_url: e.target.value })} fullWidth />
-            <TextField label="Estilo especial (opcional)" value={formData.style_override} onChange={e => setFormData({ ...formData, style_override: e.target.value })} fullWidth placeholder="boca, river, etc." />
             <FormControlLabel
               control={
                 <Checkbox
@@ -746,7 +735,12 @@ export default function ProgramsPage() {
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseDialog}>Cancelar</Button>
-          <Button onClick={handleSubmit} variant="contained">{editingProgram ? 'Actualizar' : 'Crear'}</Button>
+          <Button onClick={handleSubmit} variant="contained" disabled={isSubmitting} sx={{ position: 'relative' }}>
+            <Box sx={{ visibility: isSubmitting ? 'hidden' : 'visible' }}>
+              {editingProgram ? 'Actualizar' : 'Crear'}
+            </Box>
+            {isSubmitting && <CircularProgress size={20} color="inherit" sx={{ position: 'absolute' }} />}
+          </Button>
         </DialogActions>
       </Dialog>
 
@@ -814,6 +808,36 @@ export default function ProgramsPage() {
           </Button>
           <Button variant="contained" color="error" onClick={() => handleDeleteConfirmed(linkedDeleteDialog.program!.id, true)}>
             Eliminar todos los vinculados
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Single-program delete confirmation dialog */}
+      <Dialog open={confirmDeleteDialog.open} onClose={() => setConfirmDeleteDialog({ open: false, program: null })} maxWidth="sm" fullWidth>
+        <DialogTitle>Eliminar programa</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            ¿Estás seguro que querés eliminar <strong>{confirmDeleteDialog.program?.name}</strong>
+            {channels.find(c => c.id === confirmDeleteDialog.program?.channel_id)?.name
+              ? ` (${channels.find(c => c.id === confirmDeleteDialog.program?.channel_id)?.name})`
+              : ''}
+            ?
+          </Typography>
+          <Alert severity="warning">
+            Esta acción eliminará también todos los horarios y overrides asociados.
+          </Alert>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmDeleteDialog({ open: false, program: null })}>Cancelar</Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => {
+              setConfirmDeleteDialog({ open: false, program: null });
+              handleDeleteConfirmed(confirmDeleteDialog.program!.id, false);
+            }}
+          >
+            Eliminar
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/backoffice/PanelistsTable.tsx
+++ b/src/components/backoffice/PanelistsTable.tsx
@@ -20,12 +20,12 @@ import {
   Typography,
   Chip,
   Autocomplete,
+  CircularProgress,
   useTheme,
 } from '@mui/material';
 import { Edit, Delete, Add, Group } from '@mui/icons-material';
 import { Panelist } from '@/types/panelist';
 import { Program } from '@/types/program';
-import Image from 'next/image';
 import { useSessionContext } from '@/contexts/SessionContext';
 import type { SessionWithToken } from '@/types/session';
 
@@ -41,7 +41,8 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
   const [openDialog, setOpenDialog] = useState(false);
   const [openProgramsDialog, setOpenProgramsDialog] = useState(false);
   const [editingPanelist, setEditingPanelist] = useState<Panelist | null>(null);
-  const [formData, setFormData] = useState({ name: '', avatar_url: '' });
+  const [formData, setFormData] = useState({ name: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [selectedPrograms, setSelectedPrograms] = useState<Program[]>([]);
   const { session } = useSessionContext();
   const typedSession = session as SessionWithToken | null;
@@ -85,14 +86,11 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
   const handleOpenDialog = (panelist?: Panelist) => {
     if (panelist) {
       setEditingPanelist(panelist);
-      setFormData({
-        name: panelist.name,
-        avatar_url: panelist.avatar_url || '',
-      });
+      setFormData({ name: panelist.name });
       setSelectedPrograms(panelist.programs || []);
     } else {
       setEditingPanelist(null);
-      setFormData({ name: '', avatar_url: '' });
+      setFormData({ name: '' });
       setSelectedPrograms([]);
     }
     setOpenDialog(true);
@@ -107,7 +105,7 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
   const handleCloseDialog = () => {
     setOpenDialog(false);
     setEditingPanelist(null);
-    setFormData({ name: '', avatar_url: '' });
+    setFormData({ name: '' });
     setSelectedPrograms([]);
   };
 
@@ -120,6 +118,7 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
+      setIsSubmitting(true);
       const url = editingPanelist
         ? `/api/panelists/${editingPanelist.id}`
         : `/api/panelists`;
@@ -141,6 +140,8 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
     } catch (error) {
       onError('Error saving panelist');
       console.error('Error:', error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -240,7 +241,6 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
           <TableHead>
             <TableRow>
               <TableCell>Name</TableCell>
-              <TableCell>Avatar</TableCell>
               <TableCell>Programs</TableCell>
               <TableCell>Actions</TableCell>
             </TableRow>
@@ -249,18 +249,6 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
             {filteredPanelists.map(panelist => (
               <TableRow key={panelist.id}>
                 <TableCell>{panelist.name}</TableCell>
-                <TableCell>
-                  {panelist.avatar_url && (
-                    <Image
-                      unoptimized
-                      src={panelist.avatar_url}
-                      alt={panelist.name}
-                      width={50}
-                      height={50}
-                      style={{ objectFit: 'cover' }}
-                    />
-                  )}
-                </TableCell>
                 <TableCell>
                   <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
                     {panelist.programs?.map(program => (
@@ -303,18 +291,14 @@ export default function PanelistsTable({ onError }: PanelistsTableProps) {
               onChange={e => setFormData({ ...formData, name: e.target.value })}
               required
             />
-            <TextField
-              margin="dense"
-              label="Avatar URL"
-              fullWidth
-              value={formData.avatar_url}
-              onChange={e => setFormData({ ...formData, avatar_url: e.target.value })}
-            />
           </DialogContent>
           <DialogActions>
             <Button onClick={handleCloseDialog}>Cancel</Button>
-            <Button type="submit" variant="contained">
-              {editingPanelist ? 'Save' : 'Add'}
+            <Button type="submit" variant="contained" disabled={isSubmitting} sx={{ position: 'relative' }}>
+              <Box sx={{ visibility: isSubmitting ? 'hidden' : 'visible' }}>
+                {editingPanelist ? 'Save' : 'Add'}
+              </Box>
+              {isSubmitting && <CircularProgress size={20} color="inherit" sx={{ position: 'absolute' }} />}
             </Button>
           </DialogActions>
         </form>

--- a/src/components/backoffice/WeeklyOverridesTable.tsx
+++ b/src/components/backoffice/WeeklyOverridesTable.tsx
@@ -115,7 +115,6 @@ export function WeeklyOverridesTable() {
     newStartTime: '',
     newEndTime: '',
     newDayOfWeek: '',
-    reason: '',
     panelistIds: [] as number[],
     specialProgram: {
       name: '',
@@ -132,6 +131,7 @@ export function WeeklyOverridesTable() {
   const [editingOverride, setEditingOverride] = useState<WeeklyOverride | null>(null);
   const [isEditMode, setIsEditMode] = useState(false);
   const [specialChannelIds, setSpecialChannelIds] = useState<number[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Multi-select & bulk delete for special programs
   const [selectedOverrideIds, setSelectedOverrideIds] = useState<Set<string>>(new Set());
@@ -242,7 +242,6 @@ export function WeeklyOverridesTable() {
       newStartTime: schedule.start_time,
       newEndTime: schedule.end_time,
       newDayOfWeek: schedule.day_of_week,
-      reason: '',
       panelistIds: [],
       specialProgram: {
         name: '',
@@ -265,7 +264,6 @@ export function WeeklyOverridesTable() {
       newStartTime: '',
       newEndTime: '',
       newDayOfWeek: '',
-      reason: '',
       panelistIds: program.panelists?.map(p => p.id) || [],
       specialProgram: {
         name: '',
@@ -293,7 +291,6 @@ export function WeeklyOverridesTable() {
       newStartTime: '',
       newEndTime: '',
       newDayOfWeek: '',
-      reason: '',
       panelistIds: [],
       specialProgram: {
         name: '',
@@ -310,6 +307,7 @@ export function WeeklyOverridesTable() {
     if (!selectedSchedule && !selectedProgram && formData.overrideType !== 'create' && !isEditMode) return;
 
     try {
+      setIsSubmitting(true);
       // Bulk path: special program (create) + multiple channels + not editing
       if (formData.overrideType === 'create' && !isEditMode && specialChannelIds.length > 1) {
         const bulkPayload = {
@@ -319,7 +317,6 @@ export function WeeklyOverridesTable() {
           newStartTime: formData.newStartTime,
           newEndTime: formData.newEndTime,
           newDayOfWeek: formData.newDayOfWeek,
-          reason: formData.reason,
           createdBy: typedSession?.user?.name || 'Admin',
           ...(formData.panelistIds.length > 0 && { panelistIds: formData.panelistIds }),
           specialProgram: {
@@ -368,7 +365,6 @@ export function WeeklyOverridesTable() {
         newStartTime?: string;
         newEndTime?: string;
         newDayOfWeek?: string;
-        reason?: string;
         createdBy?: string;
         scheduleId?: number;
         programId?: number;
@@ -417,7 +413,6 @@ export function WeeklyOverridesTable() {
         ...(formData.panelistIds.length > 0 && {
           panelistIds: formData.panelistIds,
         }),
-        reason: formData.reason,
         createdBy: typedSession?.user?.name || 'Admin',
       };
 
@@ -468,6 +463,8 @@ export function WeeklyOverridesTable() {
     } catch (err) {
       console.error('Error creating override:', err);
       setError(err instanceof Error ? err.message : 'Error al crear el cambio');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -529,7 +526,6 @@ export function WeeklyOverridesTable() {
       newStartTime: override.newStartTime || '',
       newEndTime: override.newEndTime || '',
       newDayOfWeek: override.newDayOfWeek || '',
-      reason: override.reason || '',
       panelistIds: override.panelistIds || [],
       specialProgram: override.specialProgram ? {
         name: override.specialProgram.name || '',
@@ -792,7 +788,6 @@ export function WeeklyOverridesTable() {
                 <TableCell>Horario Original</TableCell>
                 <TableCell>Cambio</TableCell>
                 <TableCell>Panelistas</TableCell>
-                <TableCell>Motivo</TableCell>
                 <TableCell>Acciones</TableCell>
               </TableRow>
             </TableHead>
@@ -875,7 +870,6 @@ export function WeeklyOverridesTable() {
                         <Typography variant="body2" color="text.secondary">—</Typography>
                       )}
                     </TableCell>
-                    <TableCell>{override.reason || '—'}</TableCell>
                     <TableCell>
                       <Box sx={{ display: 'flex', gap: 1 }}>
                         <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
@@ -913,7 +907,6 @@ export function WeeklyOverridesTable() {
                 <TableCell>Horario Original</TableCell>
                 <TableCell>Cambio</TableCell>
                 <TableCell>Panelistas</TableCell>
-                <TableCell>Motivo</TableCell>
                 <TableCell>Acciones</TableCell>
               </TableRow>
             </TableHead>
@@ -996,7 +989,6 @@ export function WeeklyOverridesTable() {
                         <Typography variant="body2" color="text.secondary">—</Typography>
                       )}
                     </TableCell>
-                    <TableCell>{override.reason || '—'}</TableCell>
                     <TableCell>
                       <Box sx={{ display: 'flex', gap: 1 }}>
                         <IconButton aria-label="Editar" onClick={() => handleEdit(override)} color="primary">
@@ -1300,7 +1292,6 @@ export function WeeklyOverridesTable() {
                 newStartTime: '',
                 newEndTime: '',
                 newDayOfWeek: '',
-                reason: '',
                 panelistIds: [],
                 specialProgram: {
                   name: '',
@@ -1801,32 +1792,28 @@ export function WeeklyOverridesTable() {
               </>
             )}
 
-            <TextField
-              label="Motivo del cambio"
-              value={formData.reason}
-              onChange={(e) => setFormData({ ...formData, reason: e.target.value })}
-              fullWidth
-              multiline
-              rows={2}
-              placeholder="Ej: Programa especial por día festivo, cambio de horario por evento, etc."
-            />
           </Box>
         </DialogContent>
         <DialogActions sx={{ p: 3, gap: 1 }}>
           <Button onClick={handleCloseDialog} variant="outlined">
             Cancelar
           </Button>
-          <Button 
-            onClick={handleSubmit} 
-            variant="contained" 
-            startIcon={isEditMode ? <Edit /> : <Add />}
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
             disabled={
-              formData.overrideType !== 'cancel' && 
-              (!formData.newStartTime || !formData.newEndTime || 
-               (formData.overrideType === 'reschedule' && !formData.newDayOfWeek))
+              isSubmitting ||
+              (formData.overrideType !== 'cancel' &&
+              (!formData.newStartTime || !formData.newEndTime ||
+               (formData.overrideType === 'reschedule' && !formData.newDayOfWeek)))
             }
+            sx={{ position: 'relative' }}
           >
-            {isEditMode ? 'Actualizar Cambio' : 'Crear Cambio'}
+            <Box sx={{ visibility: isSubmitting ? 'hidden' : 'visible', display: 'flex', alignItems: 'center', gap: 0.75 }}>
+              {isEditMode ? <Edit fontSize="small" /> : <Add fontSize="small" />}
+              {isEditMode ? 'Actualizar Cambio' : 'Crear Cambio'}
+            </Box>
+            {isSubmitting && <CircularProgress size={20} color="inherit" sx={{ position: 'absolute' }} />}
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
## [1.27.2] - 2026-06-28

### Changed

- **Backoffice — limpieza de campos no utilizados en dialogs**: se eliminaron del formulario de programas los campos `logo_url` y `style_override` (incluyendo la columna "Estilo especial" de la tabla), del formulario de panelistas el campo `avatar_url` (incluyendo la columna "Avatar" de la tabla), y del formulario de weekly overrides el campo `motivo` (incluyendo la columna "Motivo" de ambas tablas). Estos campos permanecen en la DB y el backend, simplemente dejan de mostrarse/enviarse desde la UI.
- **Backoffice — feedback visual al guardar**: los botones de submit de los dialogs de programas, panelistas y weekly overrides ahora muestran un spinner interno (`CircularProgress`) y se deshabilitan mientras la petición está en curso, evitando dobles envíos. El botón mantiene su tamaño original durante el estado de carga (spinner superpuesto con `position: absolute`, texto oculto con `visibility: hidden`).
- **Backoffice — logo duplicado en sidebar**: se eliminó la imagen `logo.png` redundante del sidebar; la imagen `text-white.png` / `text.png` ya incluye el logo y el texto juntos.

### Fixed

- **Backoffice programas — confirmación antes de eliminar**: el botón de eliminar (trash) en la tabla de programas ahora muestra un diálogo de confirmación con el nombre del programa y el canal al que pertenece, con opciones de confirmar o cancelar, antes de proceder con el borrado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)