### PR TITLE
🎨 Palette: Añadir aria-labels descriptivos a los botones de acciones de usuario

### DIFF
--- a/src/components/backoffice/UsersTable.tsx
+++ b/src/components/backoffice/UsersTable.tsx
@@ -415,12 +415,12 @@ export function UsersTable() {
                 <TableCell>{user.lastName}</TableCell>
                 <TableCell>{user.email}</TableCell>
                 <TableCell>
-                  <Button size="small" onClick={() => setManagingDevicesForUser(user)}>
+                  <Button size="small" aria-label={`Ver ${user.devices?.length || 0} dispositivos de ${user.email}`} onClick={() => setManagingDevicesForUser(user)}>
                     Ver ({user.devices?.length || 0})
                   </Button>
                 </TableCell>
                 <TableCell>
-                  <Button size="small" onClick={() => setManagingSubsForUser(user)}>
+                  <Button size="small" aria-label={`Ver ${user.subscriptions?.length || 0} suscripciones de ${user.email}`} onClick={() => setManagingSubsForUser(user)}>
                     Ver ({user.subscriptions?.length || 0})
                   </Button>
                 </TableCell>


### PR DESCRIPTION
💡 What: Añadí `aria-label` descriptivos a los botones de "Ver dispositivos" y "Ver suscripciones" en la tabla de usuarios del backoffice.

🎯 Why: Previamente los lectores de pantalla solo leían "Ver (X)", lo cual no tenía ningún contexto si el usuario navegaba por botones. Ahora el lector de pantalla dirá exactamente qué está viendo y de qué usuario es.

📸 Before/After: No hay cambios visuales.

♿ Accessibility: Gran mejora para usuarios de lectores de pantalla al navegar a través de tablas de datos.

---
*PR created automatically by Jules for task [4240066221780571886](https://jules.google.com/task/4240066221780571886) started by @matiasrozenblum*