### PR TITLE
🎨 Palette: Add password visibility toggle to backoffice login

### DIFF
--- a/src/app/backoffice_login/page.tsx
+++ b/src/app/backoffice_login/page.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
-import { Box, Button, TextField, Typography, Paper } from '@mui/material';
+import { Box, Button, TextField, Typography, Paper, InputAdornment, IconButton, Tooltip } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { useSessionContext } from '@/contexts/SessionContext';
 import type { SessionWithToken } from '@/types/session';
 
@@ -22,6 +24,7 @@ export default function BackofficeLoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -86,11 +89,26 @@ export default function BackofficeLoginPage() {
           <TextField
             fullWidth
             label="Password"
-            type="password"
+            type={showPassword ? 'text' : 'password'}
             value={password}
             onChange={e => setPassword(e.target.value)}
             error={!!error}
             helperText={error}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <Tooltip title={showPassword ? 'Hide password' : 'Show password'}>
+                    <IconButton
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                      edge="end"
+                      onClick={() => setShowPassword(!showPassword)}
+                    >
+                      {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                    </IconButton>
+                  </Tooltip>
+                </InputAdornment>
+              ),
+            }}
           />
           <Button fullWidth variant="contained" type="submit" sx={{ mt: 2 }}>
             Login


### PR DESCRIPTION
💡 **What:** Added a "show/hide password" visibility toggle to the password input field on the backoffice login page.
🎯 **Why:** To improve user experience by allowing administrators to easily verify their typed password before submitting, reducing frustration and login errors.
📸 **Before/After:** The password field now includes an eye icon on the right side that toggles between showing the password as plain text and hiding it as asterisks.
♿ **Accessibility:** The toggle button includes descriptive `aria-label`s and a `Tooltip` ('Show password' / 'Hide password') that dynamically update based on the current visibility state, ensuring screen reader users understand the button's purpose and state. The labels were localized in English to match the rest of the form's UI.

---
*PR created automatically by Jules for task [18144427388519324313](https://jules.google.com/task/18144427388519324313) started by @matiasrozenblum*