### PR TITLE
🎨 Palette: Add context-rich aria-labels to 'Volver' buttons in auth flow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2024-05-18 - Missing ARIA Labels on secondary navigation flows like "Volver"
+**Learning:** For multi-step or wizard-like navigation flows (such as authentication steps), secondary navigation buttons (e.g., "Volver") lack context-rich `aria-label` attributes in Spanish to improve accessibility for screen readers.
+**Action:** Always ensure secondary navigation buttons (e.g., "Volver") include context-rich `aria-label` attributes in Spanish (e.g., "Volver al paso anterior") to improve accessibility for screen readers.

--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -187,6 +187,7 @@ export default function CodeStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -131,6 +131,7 @@ export default function ExistingUserStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -154,6 +154,7 @@ export default function PasswordStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -171,6 +171,7 @@ export default function ProfileStep({
             startIcon={<ArrowBackIosNewIcon fontSize="small" />}
             fullWidth
             onClick={onBack}
+            aria-label="Volver al paso anterior"
           >
             Volver
           </Button>


### PR DESCRIPTION
### 💡 What
Added `aria-label="Volver al paso anterior"` to the "Volver" `<Button>` components across the authentication flow steps.

### 🎯 Why
In multi-step navigation flows, a button simply labeled "Volver" (Back) might lack sufficient context for screen reader users regarding what action is being taken or where they are returning. Adding a descriptive `aria-label` ensures a more accessible experience without changing the visual design.

### ♿ Accessibility
Improves screen reader context by expanding the accessible name of the back buttons to explicitly state the destination/action ("Volver al paso anterior").

---
*PR created automatically by Jules for task [3530281301639826938](https://jules.google.com/task/3530281301639826938) started by @matiasrozenblum*