### PR TITLE
🎨 Palette: Add tooltips to YouTube global player controls

### DIFF
--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, Typography, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Typography, useMediaQuery, Tooltip } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
@@ -304,17 +304,19 @@ export const YouTubeGlobalPlayer = () => {
           >
             {/* Zap toggle */}
             {!minimized && hasZapItems && (
-              <IconButton
-                aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
-                onClick={() => setZapOpen((v) => !v)}
-                size="small"
-                sx={{
-                  color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
-                  '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
-                }}
-              >
-                <FormatListBulletedIcon fontSize="small" />
-              </IconButton>
+              <Tooltip title={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'} arrow placement="top">
+                <IconButton
+                  aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
+                  onClick={() => setZapOpen((v) => !v)}
+                  size="small"
+                  sx={{
+                    color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
+                    '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
+                  }}
+                >
+                  <FormatListBulletedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
             )}
 
             {/* Channel / streamer mini-logo + name */}
@@ -367,23 +369,27 @@ export const YouTubeGlobalPlayer = () => {
 
             <Box sx={{ flex: 1 }} />
 
-            <IconButton
-              aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
-              onClick={minimized ? maximizePlayer : minimizePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'} arrow placement="top">
+              <IconButton
+                aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
+                onClick={minimized ? maximizePlayer : minimizePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
 
-            <IconButton
-              aria-label="Cerrar reproductor"
-              onClick={closePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CloseIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Cerrar reproductor" arrow placement="top">
+              <IconButton
+                aria-label="Cerrar reproductor"
+                onClick={closePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           </Box>
 
           {/* iframe */}


### PR DESCRIPTION
### 💡 What
Wrapped the three main icon-only action buttons (Zap toggle, Minimize/Maximize, Close) in the `YouTubeGlobalPlayer` component with MUI Tooltips.

### 🎯 Why
Icon-only buttons can be ambiguous for sighted users. While they already possessed `aria-label`s for screen readers, adding tooltips provides the same context on hover/focus for all users, fulfilling a core accessibility and micro-UX goal.

### 📸 Before/After
*   **Before:** Hovering over the buttons showed a hover state but no text explanation.
*   **After:** Hovering over the buttons displays native Material UI tooltips with Spanish text describing the action (e.g., 'Cerrar lista de canales').

### ♿ Accessibility
This enhances the experience for sighted keyboard users and mouse users by exposing the actions that were previously hidden behind the icon imagery, all while preserving the underlying `aria-label` structure for assistive technology.

---
*PR created automatically by Jules for task [14707434698959012486](https://jules.google.com/task/14707434698959012486) started by @matiasrozenblum*