### PR TITLE
🎨 Palette: [UX] Add tooltips to YouTube Global Player controls

### DIFF
--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, Typography, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Tooltip, Typography, useMediaQuery } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
@@ -304,17 +304,19 @@ export const YouTubeGlobalPlayer = () => {
           >
             {/* Zap toggle */}
             {!minimized && hasZapItems && (
-              <IconButton
-                aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
-                onClick={() => setZapOpen((v) => !v)}
-                size="small"
-                sx={{
-                  color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
-                  '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
-                }}
-              >
-                <FormatListBulletedIcon fontSize="small" />
-              </IconButton>
+              <Tooltip title={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'} arrow>
+                <IconButton
+                  aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
+                  onClick={() => setZapOpen((v) => !v)}
+                  size="small"
+                  sx={{
+                    color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
+                    '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
+                  }}
+                >
+                  <FormatListBulletedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
             )}
 
             {/* Channel / streamer mini-logo + name */}
@@ -367,23 +369,27 @@ export const YouTubeGlobalPlayer = () => {
 
             <Box sx={{ flex: 1 }} />
 
-            <IconButton
-              aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
-              onClick={minimized ? maximizePlayer : minimizePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'} arrow>
+              <IconButton
+                aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
+                onClick={minimized ? maximizePlayer : minimizePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
 
-            <IconButton
-              aria-label="Cerrar reproductor"
-              onClick={closePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CloseIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Cerrar reproductor" arrow>
+              <IconButton
+                aria-label="Cerrar reproductor"
+                onClick={closePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           </Box>
 
           {/* iframe */}


### PR DESCRIPTION
### 💡 What
Wrapped the icon-only control buttons (Zap toggle, maximize/minimize, close) in the `YouTubeGlobalPlayer` with Material UI `<Tooltip>` components.

### 🎯 Why
Icon-only buttons can be ambiguous for users who do not use screen readers. Tooltips provide immediate visual clarification of the button's purpose on hover or keyboard focus, reducing cognitive load and preventing accidental clicks (e.g., closing the player instead of minimizing it).

### 📸 Before/After
*(Visuals verified locally via Playwright script - tooltips appear on hover/focus over player controls)*

### ♿ Accessibility
This enhances the experience for sighted keyboard users and mouse users. The components already had robust `aria-label`s for screen readers; the tooltips reuse these strings to ensure consistent terminology across assistive and visual contexts.

---
*PR created automatically by Jules for task [10172010978392922147](https://jules.google.com/task/10172010978392922147) started by @matiasrozenblum*