### PR TITLE
🎨 Palette: Improve accessibility of 'Volver' buttons in auth flow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,7 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+
+## 2024-05-18 - Auth Flow Navigation Accessibility
+**Learning:** Found a recurring pattern in the authentication flow where secondary navigation buttons (like "Volver" / Back) lacked context for screen readers. A simple "Volver" button on a wizard step doesn't tell a non-sighted user what they are returning to.
+**Action:** Added `aria-label="Volver al paso anterior"` to these buttons across all auth steps (`CodeStep`, `ExistingUserStep`, `PasswordStep`, `ProfileStep`). When working on multi-step flows, always ensure navigation buttons have context-rich labels.

--- a/src/components/auth/steps/CodeStep.tsx
+++ b/src/components/auth/steps/CodeStep.tsx
@@ -187,6 +187,7 @@ export default function CodeStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ExistingUserStep.tsx
+++ b/src/components/auth/steps/ExistingUserStep.tsx
@@ -131,6 +131,7 @@ export default function ExistingUserStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/PasswordStep.tsx
+++ b/src/components/auth/steps/PasswordStep.tsx
@@ -154,6 +154,7 @@ export default function PasswordStep({
           fullWidth
           disabled={isLoading}
           onClick={onBack}
+          aria-label="Volver al paso anterior"
         >
           Volver
         </Button>

--- a/src/components/auth/steps/ProfileStep.tsx
+++ b/src/components/auth/steps/ProfileStep.tsx
@@ -171,6 +171,7 @@ export default function ProfileStep({
             startIcon={<ArrowBackIosNewIcon fontSize="small" />}
             fullWidth
             onClick={onBack}
+            aria-label="Volver al paso anterior"
           >
             Volver
           </Button>


### PR DESCRIPTION
### 💡 What
Added context-rich `aria-label` attributes (`aria-label="Volver al paso anterior"`) to the "Volver" (Back) buttons across the authentication multi-step flow.

### 🎯 Why
In a wizard or multi-step flow, a button labeled simply "Volver" (Back) lacks context for screen reader users. They might wonder "Back to where?". Adding a descriptive aria-label clarifies the action without changing the visual design.

### ♿ Accessibility
Improves navigation clarity for screen reader users across all authentication flow components (`CodeStep`, `ExistingUserStep`, `PasswordStep`, `ProfileStep`). Matches WCAG 2.5.3 (Label in Name) by ensuring the visible text is included in the accessible name.

---
*PR created automatically by Jules for task [8111086775357482305](https://jules.google.com/task/8111086775357482305) started by @matiasrozenblum*