### PR TITLE
🎨 Palette: Add tooltips to YouTube Global Player controls

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -2,3 +2,6 @@
 **Learning:** Found a recurring accessibility pattern in authentication and profile components where icon-only buttons for toggling password visibility (using Visibility/VisibilityOff icons) lacked `aria-label` attributes. This prevents screen readers from understanding the button's purpose and state.
 **Action:** Always ensure that icon-only buttons, specifically those dealing with sensitive or functional inputs like password visibility, have dynamic `aria-label` attributes that reflect the action (e.g., 'Mostrar contraseña' vs 'Ocultar contraseña').
 ## 2024-01-01 - Initializing Palette Journal\n**Learning:** This repo frequently uses MUI components and uses Spanish for the interface.\n**Action:** Use Spanish for aria-labels to maintain consistency. e.g. 'Editar' instead of 'Edit'.
+## 2026-07-09 - Adding Tooltips to IconButtons
+**Learning:** Sighted users can struggle with icon-only buttons that lack contextual labels, while screen readers rely solely on `aria-label`. The `IconButton` component from Material-UI is widely used in the app without visual tooltips.
+**Action:** When working on UI enhancements or adding new `IconButton` components, wrap them in a `<Tooltip>` component to ensure sighted users get the same context that `aria-label` provides for screen readers.

--- a/src/components/YouTubeGlobalPlayer.tsx
+++ b/src/components/YouTubeGlobalPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Box, IconButton, Typography, useMediaQuery } from '@mui/material';
+import { Box, IconButton, Tooltip, Typography, useMediaQuery } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import CropSquareIcon from '@mui/icons-material/CropSquare';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
@@ -304,17 +304,19 @@ export const YouTubeGlobalPlayer = () => {
           >
             {/* Zap toggle */}
             {!minimized && hasZapItems && (
-              <IconButton
-                aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
-                onClick={() => setZapOpen((v) => !v)}
-                size="small"
-                sx={{
-                  color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
-                  '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
-                }}
-              >
-                <FormatListBulletedIcon fontSize="small" />
-              </IconButton>
+              <Tooltip title={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'} arrow placement="top">
+                <IconButton
+                  aria-label={zapOpen ? 'Cerrar lista de canales' : 'Abrir lista de canales'}
+                  onClick={() => setZapOpen((v) => !v)}
+                  size="small"
+                  sx={{
+                    color: zapOpen ? '#3b82f6' : 'rgba(255,255,255,0.65)',
+                    '&:hover': { color: zapOpen ? '#60a5fa' : 'rgba(255,255,255,0.9)' },
+                  }}
+                >
+                  <FormatListBulletedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
             )}
 
             {/* Channel / streamer mini-logo + name */}
@@ -367,23 +369,27 @@ export const YouTubeGlobalPlayer = () => {
 
             <Box sx={{ flex: 1 }} />
 
-            <IconButton
-              aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
-              onClick={minimized ? maximizePlayer : minimizePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CropSquareIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'} arrow placement="top">
+              <IconButton
+                aria-label={minimized ? 'Maximizar reproductor' : 'Minimizar reproductor'}
+                onClick={minimized ? maximizePlayer : minimizePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CropSquareIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
 
-            <IconButton
-              aria-label="Cerrar reproductor"
-              onClick={closePlayer}
-              size="small"
-              sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
-            >
-              <CloseIcon fontSize="small" />
-            </IconButton>
+            <Tooltip title="Cerrar reproductor" arrow placement="top">
+              <IconButton
+                aria-label="Cerrar reproductor"
+                onClick={closePlayer}
+                size="small"
+                sx={{ color: 'rgba(255,255,255,0.65)', '&:hover': { color: '#fff' } }}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
           </Box>
 
           {/* iframe */}


### PR DESCRIPTION
🎨 Palette: Add tooltips to YouTube Global Player controls

💡 What: Wrapped the icon-only buttons in the YouTubeGlobalPlayer with `<Tooltip>` components.
🎯 Why: Improves usability for sighted users by providing visual context for what the buttons do (Open list, Minimize/Maximize, Close) before they click, matching the context already provided to screen readers via `aria-label`.
♿ Accessibility: Preserved existing `aria-label` attributes while enhancing the visual experience.

---
*PR created automatically by Jules for task [2382299169236232681](https://jules.google.com/task/2382299169236232681) started by @matiasrozenblum*