### PR TITLE
🎨 Palette: Add dynamic aria-labels to social login buttons

### DIFF
--- a/src/components/auth/LoginModal.tsx
+++ b/src/components/auth/LoginModal.tsx
@@ -434,6 +434,7 @@ export default function LoginModal({ open, onClose }: { open: boolean; onClose: 
                       setSocialLoginPending(false);
                     }}
                     disabled={socialLoginPending}
+                    aria-label={socialLoginPending ? 'Conectando con Google' : 'Conectate con Google'}
                     sx={{
                       display: 'flex',
                       alignItems: 'center',
@@ -481,6 +482,7 @@ export default function LoginModal({ open, onClose }: { open: boolean; onClose: 
                       setSocialLoginPending(false);
                     }}
                     disabled={socialLoginPending}
+                    aria-label={socialLoginPending ? 'Conectando con Apple' : 'Conectate con Apple'}
                     sx={{
                       display: 'flex',
                       alignItems: 'center',


### PR DESCRIPTION
💡 **What:** 
Added dynamic `aria-label` attributes to the Google and Apple social sign-in buttons in the `LoginModal` component.

🎯 **Why:** 
When the user clicked a social login button, the text inside the button changed to "Conectando..." but without a clear `aria-label`, screen readers might not immediately grasp the specific state transition ("Conectando con Google" instead of a generic visual indicator). Now, the buttons accurately announce their loading states and specific targets to assistive technology.

📸 **Before/After:** 
- **Before:** `<Button disabled={socialLoginPending}>...{socialLoginPending ? 'Conectando...' : 'Conectate con Google'}</Button>` (no explicit aria-label)
- **After:** `<Button aria-label={socialLoginPending ? 'Conectando con Google' : 'Conectate con Google'} ...>`

♿ **Accessibility:** 
This ensures screen reader users receive immediate, contextual, and descriptive feedback when the authentication process is pending, preventing confusion about the active state of the modal.

---
*PR created automatically by Jules for task [10675438449911687063](https://jules.google.com/task/10675438449911687063) started by @matiasrozenblum*