### PR TITLE
fix: exclude backoffice from Datadog RUM via beforeSend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 - **Tracking zapping**: se agrega el evento `zap_use` (GA4 + PostHog + Datadog) al cambiar de canal/streamer desde el panel de zapping, con propiedades `direction`, `from_name`, `from_kind`, `from_service`, `target_name`, `target_kind`, `target_service`, `target_program` y `target_is_live`, alineado con el schema del evento equivalente en mobile (`feature/subscribed-by-jwt`)
 - **Inyección de JWT en llamadas de schedule**: se agrega un request interceptor en `api.ts` que incluye automáticamente `Authorization: Bearer <token>` en todas las llamadas client-side cuando hay sesión activa, para que el backend resuelva el campo `subscribed` por userId en lugar de por deviceId (`feature/subscribed-by-jwt`)
 
+### Fixed
+- **Datadog RUM — excluir tráfico de backoffice**: se agrega `beforeSend` al `datadogRum.init()` que descarta cualquier evento RUM cuya `view.url` contenga `/backoffice`, eliminando el conteo de page views de admins del dashboard y del billing de Datadog (`fix/datadog-exclude-backoffice`)
+
 ---
 
 ## [1.27.2] - 2026-06-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 - **Inyección de JWT en llamadas de schedule**: se agrega un request interceptor en `api.ts` que incluye automáticamente `Authorization: Bearer <token>` en todas las llamadas client-side cuando hay sesión activa, para que el backend resuelva el campo `subscribed` por userId en lugar de por deviceId (`feature/subscribed-by-jwt`)
 
 ### Fixed
-- **Datadog RUM — excluir tráfico de backoffice**: se agrega `beforeSend` al `datadogRum.init()` que descarta cualquier evento RUM cuya `view.url` contenga `/backoffice`, eliminando el conteo de page views de admins del dashboard y del billing de Datadog (`fix/datadog-exclude-backoffice`)
+- **Datadog RUM — excluir tráfico de admins**: se agrega `beforeSend` al `datadogRum.init()` que descarta cualquier evento RUM cuya `view.url` contenga `/backoffice`, y también cualquier evento generado por usuarios con rol `admin` navegando el sitio público. Se agrega `setDatadogUser()` llamado desde `ConditionalTrackingLoader` al cargar la sesión, que propaga el rol a Datadog y actualiza el flag de `beforeSend`, resolviendo la race condition donde Datadog se inicializaba antes de que la sesión estuviera disponible (`fix/datadog-exclude-backoffice`)
 
 ---
 

--- a/src/components/ConditionalTrackingLoader.tsx
+++ b/src/components/ConditionalTrackingLoader.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 import { useCookieConsent } from '@/contexts/CookieConsentContext';
 import { useSessionContext } from '@/contexts/SessionContext';
-import { GA_TRACKING_ID, initDatadogRum } from '@/lib/gtag';
+import { GA_TRACKING_ID, initDatadogRum, setDatadogUser } from '@/lib/gtag';
 import posthog from 'posthog-js';
 import type { SessionWithToken } from '@/types/session';
 
@@ -57,6 +57,14 @@ export function ConditionalTrackingLoader() {
     if (isAdmin) return;
     initDatadogRum();
   }, [isAdmin]);
+
+  // Propagate user role to Datadog as soon as the session is available.
+  // beforeSend uses this to drop events from admin users even when Datadog
+  // initialized before the session loaded (async race on first render).
+  useEffect(() => {
+    if (!typedSession?.user?.role) return;
+    setDatadogUser(typedSession.user.role);
+  }, [typedSession?.user?.role]);
 
   // Initialize Google Analytics when analytics consent is given (skip for admin users)
   useEffect(() => {

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -1,5 +1,6 @@
 import posthog from 'posthog-js';
 import { datadogRum } from '@datadog/browser-rum';
+import type { RumEvent } from '@datadog/browser-rum';
 
 export const GA_TRACKING_ID = 'G-WP58Q5S1H2';
 
@@ -29,6 +30,10 @@ export function initDatadogRum(): void {
       trackResources: true,
       trackLongTasks: true,
       defaultPrivacyLevel: 'mask-user-input',
+      beforeSend: (event: RumEvent) => {
+        if ((event.view?.url ?? '').includes('/backoffice')) return false;
+        return true;
+      },
     });
     datadogRum.startSessionReplayRecording();
     datadogInited = true;

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -4,9 +4,12 @@ import type { RumEvent } from '@datadog/browser-rum';
 
 export const GA_TRACKING_ID = 'G-WP58Q5S1H2';
 
-// Module-level flag — avoids calling datadogRum.getInitConfiguration() which
+// Module-level flags — avoids calling datadogRum.getInitConfiguration() which
 // throws a TrustedScript CSP error in Next.js on some browsers.
 let datadogInited = false;
+// Captured by beforeSend closure; updated when session loads so admin events
+// are dropped even if Datadog initialized before the session was available.
+let isAdminSession = false;
 
 export function initDatadogRum(): void {
   if (datadogInited) return;
@@ -32,6 +35,7 @@ export function initDatadogRum(): void {
       defaultPrivacyLevel: 'mask-user-input',
       beforeSend: (event: RumEvent) => {
         if ((event.view?.url ?? '').includes('/backoffice')) return false;
+        if (isAdminSession) return false;
         return true;
       },
     });
@@ -39,6 +43,13 @@ export function initDatadogRum(): void {
     datadogInited = true;
   } catch (e) {
     console.warn('[Datadog] init FAILED:', e);
+  }
+}
+
+export function setDatadogUser(role: string): void {
+  isAdminSession = role === 'admin';
+  if (datadogInited) {
+    datadogRum.setUser({ role });
   }
 }
 


### PR DESCRIPTION
## Summary

El SDK de Datadog RUM auto-trackea cada cambio de ruta de la SPA independientemente del check `if (user?.role === 'admin') return` que existe en `pageview()`, porque ese check sólo corre dentro del gate de consentimiento — el auto-tracking del SDK corre siempre.

Se agrega `beforeSend` al `datadogRum.init()` que descarta **todos los eventos RUM** (views, actions, resources, errors) cuya `view.url` contenga `/backoffice`. Esto elimina el tráfico interno del dashboard y del billing de Datadog sin afectar la cobertura del sitio público.

## Cambio

`src/lib/gtag.ts` — dentro de `datadogRum.init({...})`:

```ts
beforeSend: (event: RumEvent) => {
  if ((event.view?.url ?? '').includes('/backoffice')) return false;
  return true;
},
```

## Por qué `beforeSend` y no `trackViewsManually`

`trackViewsManually: true` requeriría mover los `startView()` fuera del gate de consentimiento, lo que reduciría la cobertura de usuarios sin consentimiento. `beforeSend` mantiene el tracking amplio (opt-out) y sólo filtra backoffice.

## Test plan

- [x] Build limpio (`npm run build` sin errores de TypeScript)
- [ ] Tras deploy: verificar en Datadog RUM → "Overall Page Performance" que las views de `/backoffice` dejan de aparecer

🤖 Generated with [Claude Code](https://claude.com/claude-code)