### PR TITLE
fix: mostrar encendidos los bloques de programas que siguen en vivo pasados de horario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.30.0] - 2026-07-29
+
+### Fixed
+- **Programas estirados de horario se veían apagados aunque siguieran en vivo**: cuando una transmisión se pasa de su bloque (cargado 13:00–15:00 pero sigue al aire a las 15:15), el backend ahora devuelve el programa como `is_live: true` (ver *overtime* en backend 1.40.0), pero el bloque se seguía renderizando como pasado: fondo, borde y texto atenuados, y el CTA del tooltip decía "Ver en YouTube" en lugar de "Ver en vivo". La causa era que `isPast` en `ProgramBlock.tsx` se calculaba solo contra el reloj y le ganaba a `isLive` en las ramas de estilo. Ahora un programa al aire deja de considerarse pasado, lo que corrige los 8 puntos de estilo que dependían de `isPast` de una sola vez, en lugar de parchear el fondo y dejar borde y texto apagados. El badge "EN VIVO" queda sin cambios a propósito: un programa en overtime se lee como simplemente en vivo. Con esto el canal también vuelve a aparecer en la lista de zapping mientras la transmisión continúe.
+
+---
+
 ## [1.29.1] - 2026-07-27
 
 ### Fixed

--- a/src/components/ProgramBlock.tsx
+++ b/src/components/ProgramBlock.tsx
@@ -148,7 +148,10 @@ export const ProgramBlock: React.FC<Props> = ({
   if (offset >= 1440) {
     parsedEndWithDate = parsedEndWithDate.add(Math.floor(offset / 1440), 'day');
   }
-  const isPast = isToday && now.isAfter(parsedEndWithDate);
+  // A program still on air is not past, even once its scheduled block ended:
+  // it may be in overtime because its stream never stopped. Without this, the
+  // block renders greyed out (and its CTA muted) while it is actually live.
+  const isPast = isToday && now.isAfter(parsedEndWithDate) && !isLive;
 
   // Calculate background opacity as in the default style
   let backgroundOpacity = 0.15;

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -16,6 +16,8 @@ export interface Schedule {
     description: string | null;
     stream_url: string | null;
     is_live: boolean;
+    /** Live past its scheduled end because the stream never stopped. */
+    live_overtime?: boolean;
     live_streams?: LiveStream[] | null;
     stream_count?: number;
     panelists: { id: number; name: string }[];


### PR DESCRIPTION
## Contexto

Acompaña a `streaming-guide-backend` #398 (*overtime*): un programa cuyo bloque programado terminó sigue marcado en vivo mientras su transmisión no corte. Sin este cambio, el backend devuelve el programa como `is_live: true` pero la web lo sigue mostrando apagado.

## Problema

Con el programa cargado 13:00–15:00 y la transmisión todavía al aire a las 15:15, el bloque se renderizaba como pasado: fondo, borde y texto atenuados, y el CTA del tooltip decía "Ver en YouTube" en vez de "Ver en vivo".

La causa es que `isPast` se calculaba solo contra el reloj y le ganaba a `isLive` en las ramas de estilo.

## Solución

Un programa al aire deja de considerarse pasado:

```ts
const isPast = isToday && now.isAfter(parsedEndWithDate) && !isLive;
```

`isPast` alimentaba **8 puntos de estilo** (fondo, borde, opacidad de texto, colores, hover). Parchear solo la opacidad del fondo — que era el plan original — habría dejado el bloque encendido pero con borde y texto apagados. Con esta forma los ocho quedan coherentes de una.

## Lo que no cambió

- **El badge "EN VIVO" queda igual**, por pedido explícito: un programa en overtime se lee como simplemente en vivo, sin distintivo extra.
- **No se estira la geometría del bloque** hasta el minuto actual: rompería el lane layout de programas solapados y mentiría sobre la grilla.
- **El resto fluye solo**: `ScheduleRow.tsx:337` ya mergea `liveStatus[scheduleId]` sobre el schedule y el mapeo de `ScheduleGridDesktop`/`Mobile` ya pasa el flag, así que no hizo falta plomería nueva. El CTA del tooltip ya decía "Ver en vivo" con `is_live` en true, y la lista de zapping (`HomeClient.tsx:213`) hereda el fix — el canal deja de desaparecer cuando el programa se pasa de horario.

## Cambios

- `ProgramBlock.tsx` — la corrección de precedencia.
- `types/schedule.ts` — se agrega `live_overtime?: boolean`, que el backend ahora envía junto a `is_live`. No se renderiza distinto; sirve para debug y analytics.

## Testing

- `npm run lint` y `npm run build` sin errores nuevos.
- Validado en staging con un canal real estirándose de horario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZA6G5Dh9jEJN77vsZZNiT